### PR TITLE
:twisted_rightwards_arrows: 네이버 로그인 및 애플로그인을 통한 왁뮤 서버 토큰 받아오기

### DIFF
--- a/Projects/App/Sources/Application/AppComponent+Auth.swift
+++ b/Projects/App/Sources/Application/AppComponent+Auth.swift
@@ -49,6 +49,13 @@ public extension AppComponent {
         }
     }
     
+    var fetchNaverUserInfoUseCase: any FetchNaverUserInfoUseCase {
+        
+        shared {
+            FetchNaverUserInfoUseCaseImpl(authRepository: authRepository)
+        }
+    }
+    
     
   
     

--- a/Projects/App/Sources/Application/AppComponent+Auth.swift
+++ b/Projects/App/Sources/Application/AppComponent+Auth.swift
@@ -1,0 +1,55 @@
+//
+//  AppComponent+Search.swift
+//  WaktaverseMusic
+//
+//  Created by yongbeomkwak on 2023/02/07.
+//  Copyright © 2023 yongbeomkwak. All rights reserved.
+//
+
+import DomainModule
+import DataModule
+import NetworkModule
+import CommonFeature
+import SignInFeature
+import StorageFeature
+
+//MARK: 변수명 주의
+// AppComponent 내 변수 == Dependency 내 변수  이름 같아야함
+
+
+public extension AppComponent {
+    
+    var signInComponent : SignInComponent {
+        SignInComponent(parent: self)
+    }
+    
+
+    var storageComponent : StorageComponent {
+        
+        StorageComponent(parent: self)
+        
+    }
+    
+   
+    
+    var remoteAuthDataSource: any RemoteAuthDataSource {
+        shared {
+            RemoteAuthDataSourceImpl(keychain: keychain)
+        }
+    }
+    var authRepository: any AuthRepository {
+        shared {
+            AuthRepositoryImpl(remoteAuthDataSource: remoteAuthDataSource)
+        }
+    }
+    var fetchTokenUseCase: any FetchTokenUseCase {
+        
+        shared {
+            FetchTokenUseCaseImpl(authRepository: authRepository)
+        }
+    }
+    
+    
+  
+    
+}

--- a/Projects/App/Sources/Application/NeedleGenerated.swift
+++ b/Projects/App/Sources/Application/NeedleGenerated.swift
@@ -19,7 +19,9 @@ import RxCocoa
 import RxKeyboard
 import RxSwift
 import SearchFeature
+import SignInFeature
 import SnapKit
+import StorageFeature
 import UIKit
 import Utility
 
@@ -109,6 +111,9 @@ private class MainTabBarDependencycd05b79389a6a7a6c20fProvider: MainTabBarDepend
     var artistComponent: ArtistComponent {
         return appComponent.artistComponent
     }
+    var storageComponent: StorageComponent {
+        return appComponent.storageComponent
+    }
     private let appComponent: AppComponent
     init(appComponent: AppComponent) {
         self.appComponent = appComponent
@@ -148,6 +153,19 @@ private class MainContainerDependencyd9d908a1d0cf8937bbadProvider: MainContainer
 private func factory8e19f48d5d573d3ea539f47b58f8f304c97af4d5(_ component: NeedleFoundation.Scope) -> AnyObject {
     return MainContainerDependencyd9d908a1d0cf8937bbadProvider(appComponent: parent1(component) as! AppComponent)
 }
+private class StorageDependency1447167c38e97ef97427Provider: StorageDependency {
+    var signInComponent: SignInComponent {
+        return appComponent.signInComponent
+    }
+    private let appComponent: AppComponent
+    init(appComponent: AppComponent) {
+        self.appComponent = appComponent
+    }
+}
+/// ^->AppComponent->StorageComponent
+private func factory2415399d25299b97b98bf47b58f8f304c97af4d5(_ component: NeedleFoundation.Scope) -> AnyObject {
+    return StorageDependency1447167c38e97ef97427Provider(appComponent: parent1(component) as! AppComponent)
+}
 private class RootDependency3944cc797a4a88956fb5Provider: RootDependency {
     var mainContainerComponent: MainContainerComponent {
         return appComponent.mainContainerComponent
@@ -160,6 +178,19 @@ private class RootDependency3944cc797a4a88956fb5Provider: RootDependency {
 /// ^->AppComponent->RootComponent
 private func factory264bfc4d4cb6b0629b40f47b58f8f304c97af4d5(_ component: NeedleFoundation.Scope) -> AnyObject {
     return RootDependency3944cc797a4a88956fb5Provider(appComponent: parent1(component) as! AppComponent)
+}
+private class SignInDependency5dda0dd015447272446cProvider: SignInDependency {
+    var fetchTokenUseCase: any FetchTokenUseCase {
+        return appComponent.fetchTokenUseCase
+    }
+    private let appComponent: AppComponent
+    init(appComponent: AppComponent) {
+        self.appComponent = appComponent
+    }
+}
+/// ^->AppComponent->SignInComponent
+private func factoryda2925fd76da866a652af47b58f8f304c97af4d5(_ component: NeedleFoundation.Scope) -> AnyObject {
+    return SignInDependency5dda0dd015447272446cProvider(appComponent: parent1(component) as! AppComponent)
 }
 private class AfterSearchDependency61822c19bc2eb46d7c52Provider: AfterSearchDependency {
     var afterSearchContentComponent: AfterSearchContentComponent {
@@ -245,6 +276,11 @@ extension AppComponent: Registration {
         localTable["remoteSearchDataSource-any RemoteSearchDataSource"] = { self.remoteSearchDataSource as Any }
         localTable["searchRepository-any SearchRepository"] = { self.searchRepository as Any }
         localTable["fetchSearchSongUseCase-any FetchSearchSongUseCase"] = { self.fetchSearchSongUseCase as Any }
+        localTable["signInComponent-SignInComponent"] = { self.signInComponent as Any }
+        localTable["storageComponent-StorageComponent"] = { self.storageComponent as Any }
+        localTable["remoteAuthDataSource-any RemoteAuthDataSource"] = { self.remoteAuthDataSource as Any }
+        localTable["authRepository-any AuthRepository"] = { self.authRepository as Any }
+        localTable["fetchTokenUseCase-any FetchTokenUseCase"] = { self.fetchTokenUseCase as Any }
         localTable["beforeSearchComponent-BeforeSearchComponent"] = { self.beforeSearchComponent as Any }
         localTable["recommendPlayListDetailComponent-PlayListDetailComponent"] = { self.recommendPlayListDetailComponent as Any }
         localTable["remotePlayListDataSource-any RemotePlayListDataSource"] = { self.remotePlayListDataSource as Any }
@@ -295,6 +331,7 @@ extension MainTabBarComponent: Registration {
     public func registerItems() {
         keyPathToName[\MainTabBarDependency.searchComponent] = "searchComponent-SearchComponent"
         keyPathToName[\MainTabBarDependency.artistComponent] = "artistComponent-ArtistComponent"
+        keyPathToName[\MainTabBarDependency.storageComponent] = "storageComponent-StorageComponent"
     }
 }
 extension BottomTabBarComponent: Registration {
@@ -309,9 +346,19 @@ extension MainContainerComponent: Registration {
         keyPathToName[\MainContainerDependency.playerComponent] = "playerComponent-PlayerComponent"
     }
 }
+extension StorageComponent: Registration {
+    public func registerItems() {
+        keyPathToName[\StorageDependency.signInComponent] = "signInComponent-SignInComponent"
+    }
+}
 extension RootComponent: Registration {
     public func registerItems() {
         keyPathToName[\RootDependency.mainContainerComponent] = "mainContainerComponent-MainContainerComponent"
+    }
+}
+extension SignInComponent: Registration {
+    public func registerItems() {
+        keyPathToName[\SignInDependency.fetchTokenUseCase] = "fetchTokenUseCase-any FetchTokenUseCase"
     }
 }
 extension AfterSearchComponent: Registration {
@@ -367,7 +414,9 @@ private func registerProviderFactory(_ componentPath: String, _ factory: @escapi
     registerProviderFactory("^->AppComponent->MainTabBarComponent", factorye547a52b3fce5887c8c7f47b58f8f304c97af4d5)
     registerProviderFactory("^->AppComponent->BottomTabBarComponent", factoryd34fa9e493604a6295bde3b0c44298fc1c149afb)
     registerProviderFactory("^->AppComponent->MainContainerComponent", factory8e19f48d5d573d3ea539f47b58f8f304c97af4d5)
+    registerProviderFactory("^->AppComponent->StorageComponent", factory2415399d25299b97b98bf47b58f8f304c97af4d5)
     registerProviderFactory("^->AppComponent->RootComponent", factory264bfc4d4cb6b0629b40f47b58f8f304c97af4d5)
+    registerProviderFactory("^->AppComponent->SignInComponent", factoryda2925fd76da866a652af47b58f8f304c97af4d5)
     registerProviderFactory("^->AppComponent->AfterSearchComponent", factoryeb2da679e35e2c4fb9a5f47b58f8f304c97af4d5)
     registerProviderFactory("^->AppComponent->AfterSearchContentComponent", factorycaaccdf52467bfa87f73e3b0c44298fc1c149afb)
     registerProviderFactory("^->AppComponent->SearchComponent", factorye3d049458b2ccbbcb3b6f47b58f8f304c97af4d5)

--- a/Projects/App/Sources/Application/NeedleGenerated.swift
+++ b/Projects/App/Sources/Application/NeedleGenerated.swift
@@ -183,6 +183,9 @@ private class SignInDependency5dda0dd015447272446cProvider: SignInDependency {
     var fetchTokenUseCase: any FetchTokenUseCase {
         return appComponent.fetchTokenUseCase
     }
+    var fetchNaverUserInfoUseCase: any FetchNaverUserInfoUseCase {
+        return appComponent.fetchNaverUserInfoUseCase
+    }
     private let appComponent: AppComponent
     init(appComponent: AppComponent) {
         self.appComponent = appComponent
@@ -281,6 +284,7 @@ extension AppComponent: Registration {
         localTable["remoteAuthDataSource-any RemoteAuthDataSource"] = { self.remoteAuthDataSource as Any }
         localTable["authRepository-any AuthRepository"] = { self.authRepository as Any }
         localTable["fetchTokenUseCase-any FetchTokenUseCase"] = { self.fetchTokenUseCase as Any }
+        localTable["fetchNaverUserInfoUseCase-any FetchNaverUserInfoUseCase"] = { self.fetchNaverUserInfoUseCase as Any }
         localTable["beforeSearchComponent-BeforeSearchComponent"] = { self.beforeSearchComponent as Any }
         localTable["recommendPlayListDetailComponent-PlayListDetailComponent"] = { self.recommendPlayListDetailComponent as Any }
         localTable["remotePlayListDataSource-any RemotePlayListDataSource"] = { self.remotePlayListDataSource as Any }
@@ -359,6 +363,7 @@ extension RootComponent: Registration {
 extension SignInComponent: Registration {
     public func registerItems() {
         keyPathToName[\SignInDependency.fetchTokenUseCase] = "fetchTokenUseCase-any FetchTokenUseCase"
+        keyPathToName[\SignInDependency.fetchNaverUserInfoUseCase] = "fetchNaverUserInfoUseCase-any FetchNaverUserInfoUseCase"
     }
 }
 extension AfterSearchComponent: Registration {

--- a/Projects/Features/MainTabFeature/Sources/Components/MainTabBarComponent.swift
+++ b/Projects/Features/MainTabFeature/Sources/Components/MainTabBarComponent.swift
@@ -1,4 +1,5 @@
 import Foundation
+import StorageFeature
 import SearchFeature
 import ArtistFeature
 import NeedleFoundation
@@ -6,13 +7,15 @@ import NeedleFoundation
 public protocol MainTabBarDependency: Dependency {
     var searchComponent: SearchComponent { get }
     var artistComponent: ArtistComponent { get }
+    var storageComponent: StorageComponent { get }
 }
 
 public final class MainTabBarComponent: Component<MainTabBarDependency> {
     public func makeView() -> MainTabBarViewController {
         return MainTabBarViewController.viewController(
             searchComponent: self.dependency.searchComponent,
-            artistComponent: self.dependency.artistComponent
+            artistComponent: self.dependency.artistComponent,
+            storageCompoent: self.dependency.storageComponent
         )
     }
 }

--- a/Projects/Features/MainTabFeature/Sources/ViewControllers/MainTabBarViewController.swift
+++ b/Projects/Features/MainTabFeature/Sources/ViewControllers/MainTabBarViewController.swift
@@ -26,7 +26,7 @@ public class MainTabBarViewController: BaseViewController, ViewControllerFromSto
                 ChartViewController.viewController().wrapNavigationController,
                 searchComponent.makeView().wrapNavigationController,
                 artistComponent.makeView().wrapNavigationController,
-                StorageViewController.viewController().wrapNavigationController
+                storageComponent.makeView().wrapNavigationController
         ]
     }()
 
@@ -35,6 +35,7 @@ public class MainTabBarViewController: BaseViewController, ViewControllerFromSto
     
     var searchComponent: SearchComponent!
     var artistComponent: ArtistComponent!
+    var storageComponent: StorageComponent!
 
     public override func viewDidLoad() {
         super.viewDidLoad()
@@ -54,12 +55,16 @@ public class MainTabBarViewController: BaseViewController, ViewControllerFromSto
 
     public static func viewController(
         searchComponent: SearchComponent,
-        artistComponent: ArtistComponent
+        artistComponent: ArtistComponent,
+        storageCompoent: StorageComponent
     ) -> MainTabBarViewController {
         let viewController = MainTabBarViewController.viewController(storyBoardName: "Main", bundle: Bundle.module)
         
         viewController.searchComponent = searchComponent
         viewController.artistComponent = artistComponent
+        
+        
+        viewController.storageComponent = storageCompoent
 
         return viewController
     }

--- a/Projects/Features/SignInFeature/Sources/Components/SignInComponent.swift
+++ b/Projects/Features/SignInFeature/Sources/Components/SignInComponent.swift
@@ -1,0 +1,21 @@
+//
+//  SearchComponent.swift
+//  SearchFeature
+//
+//  Created by yongbeomkwak on 2023/02/10.
+//  Copyright © 2023 yongbeomkwak. All rights reserved.
+//
+
+import Foundation
+import NeedleFoundation
+import DomainModule
+
+public protocol SignInDependency: Dependency {
+    var fetchTokenUseCase: any FetchTokenUseCase {get}
+}
+
+public final class SignInComponent: Component<SignInDependency> {
+    public func makeView() -> LoginViewController {
+        return LoginViewController.viewController(viewModel: .init(fetchTokenUseCase: dependency.fetchTokenUseCase))
+    }
+}

--- a/Projects/Features/SignInFeature/Sources/Components/SignInComponent.swift
+++ b/Projects/Features/SignInFeature/Sources/Components/SignInComponent.swift
@@ -12,10 +12,11 @@ import DomainModule
 
 public protocol SignInDependency: Dependency {
     var fetchTokenUseCase: any FetchTokenUseCase {get}
+    var fetchNaverUserInfoUseCase: any FetchNaverUserInfoUseCase {get}
 }
 
 public final class SignInComponent: Component<SignInDependency> {
     public func makeView() -> LoginViewController {
-        return LoginViewController.viewController(viewModel: .init(fetchTokenUseCase: dependency.fetchTokenUseCase))
+        return LoginViewController.viewController(viewModel: .init(fetchTokenUseCase: dependency.fetchTokenUseCase,fetchNaverUserInfo: dependency.fetchNaverUserInfoUseCase))
     }
 }

--- a/Projects/Features/SignInFeature/Sources/ViewControllers/LoginViewController.swift
+++ b/Projects/Features/SignInFeature/Sources/ViewControllers/LoginViewController.swift
@@ -107,23 +107,11 @@ extension LoginViewController{
     
     private func configureApple(){
         
-        appleLoginButton.rx.tap.subscribe(onNext: { [weak self] in
-            
-            guard let self = self else{
-                return
-            }
-            
-            let appleIdProvider = ASAuthorizationAppleIDProvider()
-            let request = appleIdProvider.createRequest()
-            request.requestedScopes = [.fullName,.email]
-            
-            
-            let auth = ASAuthorizationController(authorizationRequests: [request])
-            auth.delegate = self
-            auth.presentationContextProvider = self
-            auth.performRequests()
-            
-        }).disposed(by: disposeBag)
+        appleLoginButton.rx.tap
+            .bind(to: viewModel.input.pressAppleLoginButton)
+            .disposed(by: disposeBag)
+        
+    
         
     }
     
@@ -266,27 +254,27 @@ extension LoginViewController{
 
 
 
-extension LoginViewController:ASAuthorizationControllerDelegate,ASAuthorizationControllerPresentationContextProviding{
-    
-    public func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
-        return self.view.window!
-    }
-    
-    
-    public func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
-        if let credential = authorization.credential as? ASAuthorizationAppleIDCredential {
-            
-            let userIdentifer = credential.user
-            let username = credential.fullName! // 무작위 유저네임
-            
-            
-        }
-    }
-    
-    public func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
-        DEBUG_LOG("Apple Login Fail")
-    }
-    
-    
-    
-}
+//extension LoginViewController:ASAuthorizationControllerDelegate,ASAuthorizationControllerPresentationContextProviding{
+//
+//    public func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+//        return self.view.window!
+//    }
+//
+//
+//    public func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
+//        if let credential = authorization.credential as? ASAuthorizationAppleIDCredential {
+//
+//            let userIdentifer = credential.user
+//            let username = credential.fullName! // 무작위 유저네임
+//
+//
+//        }
+//    }
+//
+//    public func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
+//        DEBUG_LOG("Apple Login Fail")
+//    }
+//
+//
+//
+//}

--- a/Projects/Features/SignInFeature/Sources/ViewControllers/LoginViewController.swift
+++ b/Projects/Features/SignInFeature/Sources/ViewControllers/LoginViewController.swift
@@ -50,7 +50,7 @@ public class LoginViewController: UIViewController, ViewControllerFromStoryBoard
     
     let disposeBag = DisposeBag()
     
-//    let naverLoginInstance = NaverThirdPartyLoginConnection.getSharedInstance()
+
     
     var viewModel:LoginViewModel!
     
@@ -82,7 +82,7 @@ extension LoginViewController{
     
     private func configureNaver(){
         
-//        naverLoginInstance?.delegate = self
+
         
         naverLoginButton.rx.tap
             .bind(to: viewModel.input.pressNaverLoginButton)
@@ -264,26 +264,7 @@ extension LoginViewController{
     
 }
 
-//extension LoginViewController:NaverThirdPartyLoginConnectionDelegate{
-//    public func oauth20ConnectionDidFinishRequestACTokenWithAuthCode() {
-//        print("네이버 로그인 성공")
-//        self.naverLoginPaser()
-//    }
-//    
-//    public func oauth20ConnectionDidFinishRequestACTokenWithRefreshToken() {
-//        print("네이버 토큰\(naverLoginInstance?.accessToken)")
-//    }
-//    
-//    public func oauth20ConnectionDidFinishDeleteToken() {
-//        print("네이버 로그아웃")
-//    }
-//    
-//    public func oauth20Connection(_ oauthConnection: NaverThirdPartyLoginConnection!, didFailWithError error: Error!) {
-//        print("에러 = \(error.localizedDescription)")
-//    }
-//    
-//    
-//}
+
 
 extension LoginViewController:ASAuthorizationControllerDelegate,ASAuthorizationControllerPresentationContextProviding{
     

--- a/Projects/Features/SignInFeature/Sources/ViewControllers/LoginViewController.swift
+++ b/Projects/Features/SignInFeature/Sources/ViewControllers/LoginViewController.swift
@@ -52,6 +52,7 @@ public class LoginViewController: UIViewController, ViewControllerFromStoryBoard
     
     let naverLoginInstance = NaverThirdPartyLoginConnection.getSharedInstance()
     
+    var viewModel:LoginViewModel!
     
     
     public override func viewDidLoad() {
@@ -66,8 +67,10 @@ public class LoginViewController: UIViewController, ViewControllerFromStoryBoard
    
     
 
-    public static func viewController() -> LoginViewController {
+    public static func viewController(viewModel:LoginViewModel) -> LoginViewController {
         let viewController = LoginViewController.viewController(storyBoardName: "SignIn", bundle: Bundle.module)
+        
+        viewController.viewModel = viewModel
         return viewController
     }
 

--- a/Projects/Features/SignInFeature/Sources/ViewControllers/LoginViewController.swift
+++ b/Projects/Features/SignInFeature/Sources/ViewControllers/LoginViewController.swift
@@ -50,9 +50,11 @@ public class LoginViewController: UIViewController, ViewControllerFromStoryBoard
     
     let disposeBag = DisposeBag()
     
-    let naverLoginInstance = NaverThirdPartyLoginConnection.getSharedInstance()
+//    let naverLoginInstance = NaverThirdPartyLoginConnection.getSharedInstance()
     
     var viewModel:LoginViewModel!
+    
+
     
     
     public override func viewDidLoad() {
@@ -80,18 +82,11 @@ extension LoginViewController{
     
     private func configureNaver(){
         
-        naverLoginInstance?.delegate = self
+//        naverLoginInstance?.delegate = self
         
-        naverLoginButton.rx.tap.subscribe (onNext:{  [weak self] in
-            guard let self = self else{
-                return
-            }
-            
-            
-            self.naverLoginInstance?.requestThirdPartyLogin() // 로그인
-            
-            //self.naverLoginInstance?.requestDeleteToken() //로그아웃
-        }).disposed(by: disposeBag)
+        naverLoginButton.rx.tap
+            .bind(to: viewModel.input.pressNaverLoginButton)
+            .disposed(by: disposeBag)
         
     }
     
@@ -244,33 +239,7 @@ extension LoginViewController{
         
     }
     
-    private func naverLoginPaser(){
-        
-        guard let accessToken = naverLoginInstance?.isValidAccessTokenExpireTimeNow() else { return }
-                
-                if !accessToken {
-                  return
-                }
-                
-                guard let tokenType = naverLoginInstance?.tokenType else { return }
-                guard let accessToken = naverLoginInstance?.accessToken else { return }
-                  
-                let requestUrl = "https://openapi.naver.com/v1/nid/me"
-                let url = URL(string: requestUrl)!
-                
-                let authorization = "\(tokenType) \(accessToken)"
-                print("TOKEN은 받앗다")
-
-        AF.request(url, method: .get, parameters: nil, encoding: JSONEncoding.default, headers: ["Authorization": authorization]).responseData{ response in
-         
-            print(response.data!)
-            
-        
-            
-         
-        }
-      
-    }
+    
     
     private func googleLogin(){
         
@@ -295,26 +264,26 @@ extension LoginViewController{
     
 }
 
-extension LoginViewController:NaverThirdPartyLoginConnectionDelegate{
-    public func oauth20ConnectionDidFinishRequestACTokenWithAuthCode() {
-        print("네이버 로그인 성공")
-        self.naverLoginPaser()
-    }
-    
-    public func oauth20ConnectionDidFinishRequestACTokenWithRefreshToken() {
-        print("네이버 토큰\(naverLoginInstance?.accessToken)")
-    }
-    
-    public func oauth20ConnectionDidFinishDeleteToken() {
-        print("네이버 로그아웃")
-    }
-    
-    public func oauth20Connection(_ oauthConnection: NaverThirdPartyLoginConnection!, didFailWithError error: Error!) {
-        print("에러 = \(error.localizedDescription)")
-    }
-    
-    
-}
+//extension LoginViewController:NaverThirdPartyLoginConnectionDelegate{
+//    public func oauth20ConnectionDidFinishRequestACTokenWithAuthCode() {
+//        print("네이버 로그인 성공")
+//        self.naverLoginPaser()
+//    }
+//    
+//    public func oauth20ConnectionDidFinishRequestACTokenWithRefreshToken() {
+//        print("네이버 토큰\(naverLoginInstance?.accessToken)")
+//    }
+//    
+//    public func oauth20ConnectionDidFinishDeleteToken() {
+//        print("네이버 로그아웃")
+//    }
+//    
+//    public func oauth20Connection(_ oauthConnection: NaverThirdPartyLoginConnection!, didFailWithError error: Error!) {
+//        print("에러 = \(error.localizedDescription)")
+//    }
+//    
+//    
+//}
 
 extension LoginViewController:ASAuthorizationControllerDelegate,ASAuthorizationControllerPresentationContextProviding{
     

--- a/Projects/Features/SignInFeature/Sources/ViewModels/LoginViewModel.swift
+++ b/Projects/Features/SignInFeature/Sources/ViewModels/LoginViewModel.swift
@@ -12,33 +12,78 @@ import RxRelay
 import BaseFeature
 import DomainModule
 import Utility
+import NaverThirdPartyLogin
 
-public  final class LoginViewModel:ViewModelType {
+
+public  final class LoginViewModel:NSObject, ViewModelType {
    
-    
 
-    let input = Input()
-    let output = Output()
+    var input = Input()
+    var output = Output()
     
+    
+    let naverLoginInstance = NaverThirdPartyLoginConnection.getSharedInstance()
     var fetchTokenUseCase: FetchTokenUseCase!
+    var fetchNaverUserInfo: FetchNaverUserInfoUseCase!
     var disposeBag = DisposeBag()
+    var naverToken:PublishSubject<(String,String)> = PublishSubject()
     
-    
-    public init(fetchTokenUseCase:FetchTokenUseCase){
+    public init(fetchTokenUseCase:FetchTokenUseCase,fetchNaverUserInfo:FetchNaverUserInfoUseCase){
         
+        super.init()
+        
+        self.naverLoginInstance?.delegate = self
         self.fetchTokenUseCase = fetchTokenUseCase
+        self.fetchNaverUserInfo = fetchNaverUserInfo
+        
+        
+        
         print("✅ LoginViewModel 생성")
         
+
         
-        fetchTokenUseCase.execute(id: "114810075525382097724", type: .google)
-            .subscribe(onSuccess: {DEBUG_LOG($0)})
-            .disposed(by: disposeBag)
+        input.pressNaverLoginButton
+            .debug("PUSH2")
+            .subscribe(onNext: {
+            
+            
+            self.naverLoginInstance?.requestThirdPartyLogin()
+            //self.naverLoginInstance?.requestDeleteToken() //로그아웃
+            
+            
+        }).disposed(by: disposeBag)
       
+        naverToken
+            .flatMap{[weak self] (tokenType:String,accessToken:String) -> Observable<NaverUserInfoEntity> in
+                
+                guard let self = self else{
+                    return Observable.empty()
+                }
+                
+               return self.fetchNaverUserInfo.execute(tokenType: tokenType, accessToken: accessToken)
+                    .asObservable()
+                    .catchAndReturn(NaverUserInfoEntity(resultcode: "", message: "", id: "", nickname: ""))
+
+            }
+            .filter({!$0.id.isEmpty})
+            .map({$0.id})
+            .flatMap { [weak self] (id:String) -> Observable<AuthLoginEntity> in
+                
+                guard let self = self else{
+                    return Observable.empty()
+                }
+                
+                return self.fetchTokenUseCase.execute(id: id, type: .naver)
+                    .catchAndReturn(AuthLoginEntity(token: ""))
+                    .asObservable()
+                    
+            }
+            .subscribe(onNext: {DEBUG_LOG($0)})
+            .disposed(by: disposeBag)
     }
 
     public struct Input {
-    
-        
+        let pressNaverLoginButton:PublishRelay<Void> = PublishRelay()
     }
 
     public struct Output {
@@ -46,11 +91,59 @@ public  final class LoginViewModel:ViewModelType {
     }
     
     public func transform(from input: Input) -> Output {
-        //hello
+ 
         let output = Output()
+        
+       
         
         
         return output
     }
 
+}
+
+extension LoginViewModel :NaverThirdPartyLoginConnectionDelegate{
+    
+
+    
+    public func oauth20ConnectionDidFinishRequestACTokenWithAuthCode() {
+    
+        guard let accessToken = naverLoginInstance?.isValidAccessTokenExpireTimeNow() else { return }
+                
+                if !accessToken {
+                  return
+                }
+                
+        guard let tokenType = naverLoginInstance?.tokenType else { return }
+        guard let accessToken = naverLoginInstance?.accessToken else { return }
+        
+        naverToken.onNext((tokenType, accessToken))
+        
+    }
+    
+    public func oauth20ConnectionDidFinishRequestACTokenWithRefreshToken() {
+        
+        guard let accessToken = naverLoginInstance?.isValidAccessTokenExpireTimeNow() else { return }
+                
+                if !accessToken {
+                  return
+                }
+                
+        guard let tokenType = naverLoginInstance?.tokenType else { return }
+        guard let accessToken = naverLoginInstance?.accessToken else { return }
+        
+        naverToken.onNext((tokenType, accessToken))
+        
+
+    }
+    
+    public func oauth20ConnectionDidFinishDeleteToken() {
+        print("네이버 로그아웃")
+    }
+    
+    public func oauth20Connection(_ oauthConnection: NaverThirdPartyLoginConnection!, didFailWithError error: Error!) {
+        print("에러 = \(error.localizedDescription)")
+    }
+    
+    
 }

--- a/Projects/Features/SignInFeature/Sources/ViewModels/LoginViewModel.swift
+++ b/Projects/Features/SignInFeature/Sources/ViewModels/LoginViewModel.swift
@@ -1,0 +1,56 @@
+//
+//  SearchViewModel.swift
+//  SearchFeature
+//
+//  Created by yongbeomkwak on 2023/01/05.
+//  Copyright © 2023 yongbeomkwak. All rights reserved.
+//
+
+import Foundation
+import RxSwift
+import RxRelay
+import BaseFeature
+import DomainModule
+import Utility
+
+public  final class LoginViewModel:ViewModelType {
+   
+    
+
+    let input = Input()
+    let output = Output()
+    
+    var fetchTokenUseCase: FetchTokenUseCase!
+    var disposeBag = DisposeBag()
+    
+    
+    public init(fetchTokenUseCase:FetchTokenUseCase){
+        
+        self.fetchTokenUseCase = fetchTokenUseCase
+        print("✅ LoginViewModel 생성")
+        
+        
+        fetchTokenUseCase.execute(id: "114810075525382097724", type: .google)
+            .subscribe(onSuccess: {DEBUG_LOG($0)})
+            .disposed(by: disposeBag)
+      
+    }
+
+    public struct Input {
+    
+        
+    }
+
+    public struct Output {
+       
+    }
+    
+    public func transform(from input: Input) -> Output {
+        //hello
+        let output = Output()
+        
+        
+        return output
+    }
+
+}

--- a/Projects/Features/StorageFeature/Sources/Components/StorageComponent.swift
+++ b/Projects/Features/StorageFeature/Sources/Components/StorageComponent.swift
@@ -1,0 +1,21 @@
+//
+//  SearchComponent.swift
+//  SearchFeature
+//
+//  Created by yongbeomkwak on 2023/02/10.
+//  Copyright © 2023 yongbeomkwak. All rights reserved.
+//
+
+import Foundation
+import NeedleFoundation
+import SignInFeature
+
+public protocol StorageDependency: Dependency {
+    var  signInComponent : SignInComponent {get}
+}
+
+public final class StorageComponent: Component<StorageDependency> {
+    public func makeView() -> StorageViewController {
+        return StorageViewController.viewController(signInComponent: dependency.signInComponent)
+    }
+}

--- a/Projects/Features/StorageFeature/Sources/ViewControllers/StorageViewController.swift
+++ b/Projects/Features/StorageFeature/Sources/ViewControllers/StorageViewController.swift
@@ -11,9 +11,11 @@ public final class StorageViewController: BaseViewController, ViewControllerFrom
     
     @IBOutlet weak public var contentView: UIView!
     
-    var isLogin:BehaviorRelay<Bool> = BehaviorRelay(value:true)
+    var isLogin:BehaviorRelay<Bool> = BehaviorRelay(value:false)
     
-    lazy var bfLoginView = LoginViewController.viewController()
+    var signInComponent:SignInComponent!
+    
+    lazy var bfLoginView = signInComponent.makeView()
     lazy var afLoginView = AfterLoginViewController.viewController()
     let disposeBag = DisposeBag()
     
@@ -28,8 +30,11 @@ public final class StorageViewController: BaseViewController, ViewControllerFrom
         
     }
 
-    public static func viewController() -> StorageViewController {
+    public static func viewController(signInComponent:SignInComponent) -> StorageViewController {
         let viewController = StorageViewController.viewController(storyBoardName: "Storage", bundle: Bundle.module)
+        
+        viewController.signInComponent = signInComponent
+        
         return viewController
     }
 }

--- a/Projects/Features/StorageFeature/Sources/ViewControllers/StorageViewController.swift
+++ b/Projects/Features/StorageFeature/Sources/ViewControllers/StorageViewController.swift
@@ -13,7 +13,7 @@ public final class StorageViewController: BaseViewController, ViewControllerFrom
     
     
     
-    var isLogin:BehaviorRelay<Bool> = BehaviorRelay(value:true)
+    var isLogin:BehaviorRelay<Bool> = BehaviorRelay(value:false)
     
     var signInComponent:SignInComponent!
     

--- a/Projects/Features/StorageFeature/Sources/ViewControllers/StorageViewController.swift
+++ b/Projects/Features/StorageFeature/Sources/ViewControllers/StorageViewController.swift
@@ -11,7 +11,9 @@ public final class StorageViewController: BaseViewController, ViewControllerFrom
     
     @IBOutlet weak public var contentView: UIView!
     
-    var isLogin:BehaviorRelay<Bool> = BehaviorRelay(value:false)
+    
+    
+    var isLogin:BehaviorRelay<Bool> = BehaviorRelay(value:true)
     
     var signInComponent:SignInComponent!
     

--- a/Projects/Services/APIKit/Sources/API/AuthAPI.swift
+++ b/Projects/Services/APIKit/Sources/API/AuthAPI.swift
@@ -4,7 +4,7 @@ import ErrorModule
 import Foundation
 
 public enum AuthAPI {
-    case postLoginInfo(id:String,type:ProviderType)
+    case fetchToken(id:String,type:ProviderType)
     
 }
 
@@ -22,7 +22,7 @@ extension AuthAPI: WMAPI {
         
         switch self{
             
-        case .postLoginInfo:
+        case .fetchToken:
             return "/login/mobile"
         }
         
@@ -33,7 +33,7 @@ extension AuthAPI: WMAPI {
         
         switch self {
             
-        case .postLoginInfo:
+        case .fetchToken:
             return .post
         }
         
@@ -44,7 +44,7 @@ extension AuthAPI: WMAPI {
         
         switch self {
             
-        case .postLoginInfo(id: let id, type: let type):
+        case .fetchToken(id: let id, type: let type):
             return .requestJSONEncodable(AuthModel(id: id,provider: type.rawValue))
         }
         

--- a/Projects/Services/APIKit/Sources/API/AuthAPI.swift
+++ b/Projects/Services/APIKit/Sources/API/AuthAPI.swift
@@ -5,6 +5,7 @@ import Foundation
 
 public enum AuthAPI {
     case fetchToken(id:String,type:ProviderType)
+    case fetchNaverUserInfo(tokenType:String,accessToken:String)
     
 }
 
@@ -14,16 +15,40 @@ public struct AuthModel:Encodable {
 }
 
 extension AuthAPI: WMAPI {
+    
+    public var baseURL: URL {
+        
+        switch self {
+            
+        case .fetchToken:
+            return URL(string: "https://test.wakmusic.xyz")!
+        case .fetchNaverUserInfo:
+            return URL(string: "https://openapi.naver.com")!
+        }
+        
+    }
+    
+    
     public var domain: WMDomain {
-        .auth
+             
+        switch  self {
+            
+        case .fetchToken:
+            return .auth
+        case .fetchNaverUserInfo:
+            return .naver
+        }
     }
 
     public var urlPath: String {
         
-        switch self{
+  
+        switch self {
             
         case .fetchToken:
             return "/login/mobile"
+        case .fetchNaverUserInfo:
+            return ""
         }
         
        
@@ -35,9 +60,22 @@ extension AuthAPI: WMAPI {
             
         case .fetchToken:
             return .post
+        case .fetchNaverUserInfo:
+            return .get
         }
         
        
+    }
+    
+    public var headers: [String : String]? {
+        
+        switch self {
+            
+        case .fetchToken:
+            return ["Content-Type": "application/json"]
+        case .fetchNaverUserInfo(tokenType: let tokenType, accessToken: let accessToken):
+            return   ["Authorization": "\(tokenType) \(accessToken)"]
+        }
     }
 
     public var task: Moya.Task {
@@ -46,6 +84,9 @@ extension AuthAPI: WMAPI {
             
         case .fetchToken(id: let id, type: let type):
             return .requestJSONEncodable(AuthModel(id: id,provider: type.rawValue))
+            
+        case .fetchNaverUserInfo:
+            return .requestPlain
         }
         
     }

--- a/Projects/Services/APIKit/Sources/API/AuthAPI.swift
+++ b/Projects/Services/APIKit/Sources/API/AuthAPI.swift
@@ -1,0 +1,70 @@
+import Moya
+import DataMappingModule
+import ErrorModule
+import Foundation
+
+public enum AuthAPI {
+    case postLoginInfo(id:String,type:ProviderType)
+    
+}
+
+public struct AuthModel:Encodable {
+    var id:String
+    var provider:String
+}
+
+extension AuthAPI: WMAPI {
+    public var domain: WMDomain {
+        .auth
+    }
+
+    public var urlPath: String {
+        
+        switch self{
+            
+        case .postLoginInfo:
+            return "/login/mobile"
+        }
+        
+       
+    }
+
+    public var method: Moya.Method {
+        
+        switch self {
+            
+        case .postLoginInfo:
+            return .post
+        }
+        
+       
+    }
+
+    public var task: Moya.Task {
+        
+        switch self {
+            
+        case .postLoginInfo(id: let id, type: let type):
+            return .requestJSONEncodable(AuthModel(id: id,provider: type.rawValue))
+        }
+        
+    }
+
+    public var jwtTokenType: JwtTokenType {
+        return .none
+    }
+
+    public var errorMap: [Int: WMError] {
+        switch self {
+        default:
+            return [
+                400: .badRequest,
+                401: .tokenExpired,
+                404: .notFound,
+                429: .tooManyRequest,
+                500: .internalServerError
+            ]
+
+        }
+    }
+}

--- a/Projects/Services/APIKit/Sources/API/WMAPI.swift
+++ b/Projects/Services/APIKit/Sources/API/WMAPI.swift
@@ -36,6 +36,7 @@ public enum WMDomain: String {
     case playlist = "api/playlist"
     case like = "api/like"
     case common = "static"
+    case naver = "/v1/nid/me"
 }
 
 extension WMDomain {

--- a/Projects/Services/DataMappingModule/Sources/Auth/Response/AuthLoginResponseDTO.swift
+++ b/Projects/Services/DataMappingModule/Sources/Auth/Response/AuthLoginResponseDTO.swift
@@ -1,0 +1,16 @@
+//
+//  ArtistListResponseDTO.swift
+//  DataMappingModule
+//
+//  Created by KTH on 2023/02/01.
+//  Copyright © 2023 yongbeomkwak. All rights reserved.
+//
+
+import Foundation
+
+public struct AuthLoginResponseDTO: Codable, Equatable {
+    public let token:String
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        return lhs.token == rhs.token
+    }
+}

--- a/Projects/Services/DataMappingModule/Sources/Auth/Response/NaverUserInfoResponseDTO.swift
+++ b/Projects/Services/DataMappingModule/Sources/Auth/Response/NaverUserInfoResponseDTO.swift
@@ -1,0 +1,29 @@
+//
+//  NaverUserInfoResponseDTO.swift
+//  DataMappingModule
+//
+//  Created by yongbeomkwak on 2023/02/15.
+//  Copyright © 2023 yongbeomkwak. All rights reserved.
+//
+
+import Foundation
+
+public struct NaverUserInfoResponseDTO: Codable,Equatable{
+    
+    public static func == (lhs: NaverUserInfoResponseDTO, rhs: NaverUserInfoResponseDTO) -> Bool {
+        lhs.response.id == rhs.response.id
+    }
+    
+ 
+    public let resultcode, message: String
+    public let response: Response
+}
+
+
+public extension NaverUserInfoResponseDTO {
+    struct Response: Codable {
+        public let id, nickname: String
+    }
+}
+
+

--- a/Projects/Services/DataMappingModule/Sources/Base/ProviderType.swift
+++ b/Projects/Services/DataMappingModule/Sources/Base/ProviderType.swift
@@ -1,0 +1,26 @@
+//
+//  SearchType.swift
+//  DataMappingModule
+//
+//  Created by yongbeomkwak on 2023/02/07.
+//  Copyright © 2023 yongbeomkwak. All rights reserved.
+//
+
+import Foundation
+
+public enum ProviderType: String, Codable {
+    case naver
+    case apple
+    case google
+
+    public var display: String {
+        switch self {
+        case .naver:
+            return "naver"
+        case .apple:
+            return "apple"
+        case .google:
+            return "google"
+        }
+    }
+}

--- a/Projects/Services/DataModule/Sources/Auth/Repositories/AuthRepositoryImpl.swift
+++ b/Projects/Services/DataModule/Sources/Auth/Repositories/AuthRepositoryImpl.swift
@@ -1,0 +1,30 @@
+//
+//  ArtistRepositoryImpl.swift
+//  DataModule
+//
+//  Created by KTH on 2023/02/08.
+//  Copyright © 2023 yongbeomkwak. All rights reserved.
+//
+
+import DataMappingModule
+import DomainModule
+import ErrorModule
+import NetworkModule
+import DatabaseModule
+import RxSwift
+
+public struct AuthRepositoryImpl: AuthRepository {
+    
+    private let remoteAuthDataSource: any RemoteAuthDataSource
+    
+    public init(remoteAuthDataSource: RemoteAuthDataSource) {
+        self.remoteAuthDataSource = remoteAuthDataSource
+    }
+    
+    
+    public func fetchToken(id: String, type: ProviderType) -> Single<AuthLoginEntity> {
+        remoteAuthDataSource.fetchToken(id: id, type: type)
+    }
+    
+   
+}

--- a/Projects/Services/DataModule/Sources/Auth/Repositories/AuthRepositoryImpl.swift
+++ b/Projects/Services/DataModule/Sources/Auth/Repositories/AuthRepositoryImpl.swift
@@ -14,6 +14,8 @@ import DatabaseModule
 import RxSwift
 
 public struct AuthRepositoryImpl: AuthRepository {
+ 
+    
     
     private let remoteAuthDataSource: any RemoteAuthDataSource
     
@@ -26,5 +28,8 @@ public struct AuthRepositoryImpl: AuthRepository {
         remoteAuthDataSource.fetchToken(id: id, type: type)
     }
     
+    public func fetchNaverUserInfo(tokenType: String, accessToken: String) -> RxSwift.Single<DomainModule.NaverUserInfoEntity> {
+        remoteAuthDataSource.fetchNaverUserInfo(tokenType: tokenType, accessToken: accessToken)
+    }
    
 }

--- a/Projects/Services/DataModule/Sources/Auth/UseCases/FetchNaverUserInfoUseCaseImpl.swift
+++ b/Projects/Services/DataModule/Sources/Auth/UseCases/FetchNaverUserInfoUseCaseImpl.swift
@@ -12,7 +12,9 @@ import DataMappingModule
 import DomainModule
 import ErrorModule
 
-public struct FetchTokenUseCaseImpl: FetchTokenUseCase {
+public struct FetchNaverUserInfoUseCaseImpl: FetchNaverUserInfoUseCase {
+    
+    
     
     private let authRepository: any AuthRepository
     
@@ -21,9 +23,10 @@ public struct FetchTokenUseCaseImpl: FetchTokenUseCase {
     }
     
 
-    public func execute(id: String, type:ProviderType) -> Single<AuthLoginEntity> {
-        authRepository.fetchToken(id: id, type: type)
+    public func execute(tokenType: String, accessToken: String) ->Single<NaverUserInfoEntity> {
+        authRepository.fetchNaverUserInfo(tokenType: tokenType, accessToken: accessToken)
     }
+   
     
     
 

--- a/Projects/Services/DataModule/Sources/Auth/UseCases/FetchTokenUseCaseImpl.swift
+++ b/Projects/Services/DataModule/Sources/Auth/UseCases/FetchTokenUseCaseImpl.swift
@@ -1,0 +1,30 @@
+//
+//  FetchArtistListUseCaseImpl.swift
+//  DataModule
+//
+//  Created by KTH on 2023/02/08.
+//  Copyright © 2023 yongbeomkwak. All rights reserved.
+//
+
+import Foundation
+import RxSwift
+import DataMappingModule
+import DomainModule
+import ErrorModule
+
+public struct FetchTokenUseCaseImpl: FetchTokenUseCase {
+    
+    private let authRepository: any AuthRepository
+    
+    public init(authRepository: any AuthRepository) {
+        self.authRepository = authRepository
+    }
+    
+
+    public func execute(id: String, type:ProviderType) -> Single<AuthLoginEntity> {
+        authRepository.fetchToken(id: id, type: type)
+    }
+    
+
+
+}

--- a/Projects/Services/DomainModule/Sources/Auth/Entitiy/AuthLoginEntity.swift
+++ b/Projects/Services/DomainModule/Sources/Auth/Entitiy/AuthLoginEntity.swift
@@ -1,0 +1,21 @@
+//
+//  RecommendPlayListEntity.swift
+//  DomainModuleTests
+//
+//  Created by yongbeomkwak on 2023/02/10.
+//  Copyright © 2023 yongbeomkwak. All rights reserved.
+//
+
+import Foundation
+
+public struct AuthLoginEntity: Equatable {
+    public init(
+        token: String
+    ) {
+        self.token = token
+    }
+    
+    public let token: String
+ 
+    
+}

--- a/Projects/Services/DomainModule/Sources/Auth/Entitiy/NaverUserInfoEntity.swift
+++ b/Projects/Services/DomainModule/Sources/Auth/Entitiy/NaverUserInfoEntity.swift
@@ -1,0 +1,38 @@
+//
+//  NaverUserInfoResponseDTO.swift
+//  DataMappingModule
+//
+//  Created by yongbeomkwak on 2023/02/15.
+//  Copyright © 2023 yongbeomkwak. All rights reserved.
+//
+
+import Foundation
+
+public struct NaverUserInfoEntity: Equatable {
+    
+   
+    
+ 
+    public init(
+        resultcode: String,
+        message: String,
+        id:String,
+        nickname:String
+    ) {
+        self.resultcode = resultcode
+        self.message = message
+        self.id = id
+        self.nickname = nickname
+    }
+    
+    public let resultcode, message ,id, nickname : String
+    
+    
+    public static func == (lhs: NaverUserInfoEntity, rhs: NaverUserInfoEntity) -> Bool {
+        lhs.id == rhs.id
+    }
+   
+}
+
+
+

--- a/Projects/Services/DomainModule/Sources/Auth/Repository/AuthRepository.swift
+++ b/Projects/Services/DomainModule/Sources/Auth/Repository/AuthRepository.swift
@@ -6,5 +6,6 @@ import Foundation
 
 public protocol AuthRepository {
     func fetchToken(id:String,type:ProviderType) -> Single<AuthLoginEntity>
+    func fetchNaverUserInfo(tokenType:String,accessToken:String) -> Single<NaverUserInfoEntity>
 
 }

--- a/Projects/Services/DomainModule/Sources/Auth/Repository/AuthRepository.swift
+++ b/Projects/Services/DomainModule/Sources/Auth/Repository/AuthRepository.swift
@@ -5,6 +5,6 @@ import ErrorModule
 import Foundation
 
 public protocol AuthRepository {
-    func postLoginInfo(id:String,type:ProviderType) -> Single<[AuthLoginEntity]>
+    func fetchToken(id:String,type:ProviderType) -> Single<AuthLoginEntity>
 
 }

--- a/Projects/Services/DomainModule/Sources/Auth/Repository/AuthRepository.swift
+++ b/Projects/Services/DomainModule/Sources/Auth/Repository/AuthRepository.swift
@@ -1,0 +1,10 @@
+import RxSwift
+import DomainModule
+import DataMappingModule
+import ErrorModule
+import Foundation
+
+public protocol AuthRepository {
+    func postLoginInfo(id:String,type:ProviderType) -> Single<[AuthLoginEntity]>
+
+}

--- a/Projects/Services/DomainModule/Sources/Auth/UseCases/FetchNaverUserInfoUseCase.swift
+++ b/Projects/Services/DomainModule/Sources/Auth/UseCases/FetchNaverUserInfoUseCase.swift
@@ -1,0 +1,7 @@
+import Foundation
+import RxSwift
+import DataMappingModule
+
+public protocol FetchNaverUserInfoUseCase {
+    func execute(tokenType:String,accessToken:String) -> Single<NaverUserInfoEntity>
+}

--- a/Projects/Services/DomainModule/Sources/Auth/UseCases/FetchTokenUseCase.swift
+++ b/Projects/Services/DomainModule/Sources/Auth/UseCases/FetchTokenUseCase.swift
@@ -1,0 +1,7 @@
+import Foundation
+import RxSwift
+import DataMappingModule
+
+public protocol FetchTokenUseCase {
+    func execute(id:String,type:ProviderType) -> Single<AuthLoginEntity>
+}

--- a/Projects/Services/NetworkModule/Sources/Auth/DataTransfer/FetchNaverUserInfoTransfer.swift
+++ b/Projects/Services/NetworkModule/Sources/Auth/DataTransfer/FetchNaverUserInfoTransfer.swift
@@ -1,0 +1,25 @@
+//
+//  FetchArtistListTransfer.swift
+//  NetworkModuleTests
+//
+//  Created by KTH on 2023/02/08.
+//  Copyright © 2023 yongbeomkwak. All rights reserved.
+//
+
+import Foundation
+import DataMappingModule
+import DomainModule
+import Utility
+
+public extension NaverUserInfoResponseDTO {
+    func toDomain() -> NaverUserInfoEntity {
+         
+        NaverUserInfoEntity(
+            resultcode: resultcode ,
+            message: message,
+            id: response.id,
+            nickname: response.nickname
+        )
+        
+    }
+}

--- a/Projects/Services/NetworkModule/Sources/Auth/DataTransfer/FetchTokenTransfer.swift
+++ b/Projects/Services/NetworkModule/Sources/Auth/DataTransfer/FetchTokenTransfer.swift
@@ -1,0 +1,20 @@
+//
+//  FetchArtistListTransfer.swift
+//  NetworkModuleTests
+//
+//  Created by KTH on 2023/02/08.
+//  Copyright © 2023 yongbeomkwak. All rights reserved.
+//
+
+import Foundation
+import DataMappingModule
+import DomainModule
+import Utility
+
+public extension AuthLoginResponseDTO {
+    func toDomain() -> AuthLoginEntity {
+        AuthLoginEntity(
+            token:token
+        )
+    }
+}

--- a/Projects/Services/NetworkModule/Sources/Auth/Remote/RemoteAuthDataSource.swift
+++ b/Projects/Services/NetworkModule/Sources/Auth/Remote/RemoteAuthDataSource.swift
@@ -6,4 +6,5 @@ import Foundation
 
 public protocol RemoteAuthDataSource {
     func fetchToken(id:String,type:ProviderType) -> Single<AuthLoginEntity>
+    func fetchNaverUserInfo(tokenType:String,accessToken:String) -> Single<NaverUserInfoEntity>
 }

--- a/Projects/Services/NetworkModule/Sources/Auth/Remote/RemoteAuthDataSource.swift
+++ b/Projects/Services/NetworkModule/Sources/Auth/Remote/RemoteAuthDataSource.swift
@@ -1,0 +1,9 @@
+import DataMappingModule
+import ErrorModule
+import DomainModule
+import RxSwift
+import Foundation
+
+public protocol RemoteAuthDataSource {
+    func fetchToken(id:String,type:ProviderType) -> Single<AuthLoginEntity>
+}

--- a/Projects/Services/NetworkModule/Sources/Auth/Remote/RemoteAuthDataSourceImpl.swift
+++ b/Projects/Services/NetworkModule/Sources/Auth/Remote/RemoteAuthDataSourceImpl.swift
@@ -7,9 +7,17 @@ import Foundation
 
 
 public final class RemoteAuthDataSourceImpl: BaseRemoteDataSource<AuthAPI>, RemoteAuthDataSource {
+    
+    
     public func fetchToken(id: String, type: ProviderType) -> Single<AuthLoginEntity> {
         request(.fetchToken(id: id, type: type))
             .map(AuthLoginResponseDTO.self)
+            .map({$0.toDomain()})
+    }
+    
+    public func fetchNaverUserInfo(tokenType: String, accessToken: String) -> RxSwift.Single<DomainModule.NaverUserInfoEntity> {
+        request(.fetchNaverUserInfo(tokenType: tokenType, accessToken: accessToken))
+            .map(NaverUserInfoResponseDTO.self)
             .map({$0.toDomain()})
     }
     

--- a/Projects/Services/NetworkModule/Sources/Auth/Remote/RemoteAuthDataSourceImpl.swift
+++ b/Projects/Services/NetworkModule/Sources/Auth/Remote/RemoteAuthDataSourceImpl.swift
@@ -1,0 +1,19 @@
+import APIKit
+import RxSwift
+import DataMappingModule
+import DomainModule
+import ErrorModule
+import Foundation
+
+
+public final class RemoteAuthDataSourceImpl: BaseRemoteDataSource<AuthAPI>, RemoteAuthDataSource {
+    public func fetchToken(id: String, type: ProviderType) -> Single<AuthLoginEntity> {
+        request(.fetchToken(id: id, type: type))
+            .map(AuthLoginResponseDTO.self)
+            .map({$0.toDomain()})
+    }
+    
+   
+    
+ 
+}


### PR DESCRIPTION
## 개요
- LoginVC에 있던 로그인 코드를 뷰모델로 옮겨 MVVM 패턴을 구체적으로 적용
- 각 로그인을통한 id를 왁뮤서버로 보내 토큰을 받아옴