### PR TITLE
🔀 PlayState 를 만들어 Player 와 PlayerVC 를 분리합니다.

### DIFF
--- a/Projects/Features/PlayerFeature/Resources/YoutubePlayer.html
+++ b/Projects/Features/PlayerFeature/Resources/YoutubePlayer.html
@@ -1,14 +1,3 @@
-//
-//  YoutubePlayerHTML.swift
-//  PlayerFeature
-//
-//  Created by YoungK on 2023/02/20.
-//  Copyright © 2023 yongbeomkwak. All rights reserved.
-//
-
-import Foundation
-
-let playerHtml = """
 <!DOCTYPE html>
 <html>
 <head>
@@ -56,5 +45,3 @@ let playerHtml = """
     </script>
 </body>
 </html>
-
-"""

--- a/Projects/Features/PlayerFeature/Resources/YoutubePlayerHTML.swift
+++ b/Projects/Features/PlayerFeature/Resources/YoutubePlayerHTML.swift
@@ -1,0 +1,60 @@
+//
+//  YoutubePlayerHTML.swift
+//  PlayerFeature
+//
+//  Created by YoungK on 2023/02/20.
+//  Copyright © 2023 yongbeomkwak. All rights reserved.
+//
+
+import Foundation
+
+let playerHtml = """
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        html, body { margin: 0; padding: 0; width: 100%; height: 100%; background-color: #000000; }
+    </style>
+</head>
+<body>
+    <div id="player"></div>
+    <div id="explain"></div>
+    <script src="https://www.youtube.com/iframe_api" onerror="webkit.messageHandlers.onYouTubeIframeAPIFailedToLoad.postMessage('')"></script>
+    <script>
+        var player;
+        var time;
+        YT.ready(function() {
+                 player = new YT.Player('player', %@);
+                 webkit.messageHandlers.onYouTubeIframeAPIReady.postMessage('');
+                 function updateTime() {
+                     var state = player.getPlayerState();
+                     if (state == YT.PlayerState.PLAYING) {
+                        time = player.getCurrentTime();
+                        webkit.messageHandlers.onUpdateCurrentTime.postMessage(time);
+                     }
+                 }
+                 window.setInterval(updateTime, 500);
+                 });
+                 function onReady(event) {
+                     webkit.messageHandlers.onReady.postMessage('');
+                 }
+    function onStateChange(event) {
+        webkit.messageHandlers.onStateChange.postMessage(event.data);
+    }
+    function onPlaybackQualityChange(event) {
+        webkit.messageHandlers.onPlaybackQualityChange.postMessage(event.data);
+    }
+    function onPlaybackRateChange(event) {
+        webkit.messageHandlers.onPlaybackRateChange.postMessage(event.data);
+    }
+    function onError(event) {
+        webkit.messageHandlers.onError.postMessage(event.data);
+    }
+    function onApiChange(event) {
+        webkit.messageHandlers.onApiChange.postMessage(event.data);
+    }
+    </script>
+</body>
+</html>
+
+"""

--- a/Projects/Features/PlayerFeature/Sources/PlayState.swift
+++ b/Projects/Features/PlayerFeature/Sources/PlayState.swift
@@ -25,6 +25,7 @@ final public class PlayState {
         currentSong = "wSG93VZoMFg"
         progress = PlayProgress()
         playList = PlayList()
+        playList.list = ["wSG93VZoMFg", "jzt_aR_PSGo", "Gce2fYnlw0w", "UMIP5k1QvW8", "tT-kuonVzfY"]
         state = .unstarted
         
         player = YTSwiftyPlayer(
@@ -72,21 +73,24 @@ extension PlayState {
     func forWard() {
         self.playList.next()
         self.currentSong = playList.current
-        play()
+        guard let currentSong = currentSong else { return }
+        load(at: currentSong)
     }
 
     /// ⏪ 이전 곡으로 변경 후 재생
     func backWard() {
         self.playList.back()
         self.currentSong = playList.current
-        play()
+        guard let currentSong = currentSong else { return }
+        load(at: currentSong)
     }
 
     /// ♻️ 첫번째 곡으로 변경 후 재생
     func playAgain() {
         self.playList.currentPlayIndex = 0
-        currentSong = playList.first
-        play()
+        self.currentSong = playList.first
+        guard let currentSong = currentSong else { return }
+        load(at: currentSong)
     }
 
 }

--- a/Projects/Features/PlayerFeature/Sources/PlayState.swift
+++ b/Projects/Features/PlayerFeature/Sources/PlayState.swift
@@ -1,0 +1,197 @@
+//
+//  PlayState.swift
+//  PlayerFeature
+//
+//  Created by YoungK on 2023/02/20.
+//  Copyright © 2023 yongbeomkwak. All rights reserved.
+//
+
+import Foundation
+import RxSwift
+import YoutubeKit
+
+final public class PlayState {
+    public static let shared = PlayState()
+    
+    internal var player: YTSwiftyPlayer
+    internal var state: YTSwiftyPlayerState
+    
+    private let disposeBag = DisposeBag()
+    private var currentSong: String?
+    private var progress: PlayProgress
+    private var playList: PlayList
+    
+    init() {
+        currentSong = "wSG93VZoMFg"
+        progress = PlayProgress()
+        playList = PlayList()
+        state = .unstarted
+        
+        player = YTSwiftyPlayer(
+            frame: .init(x: 0, y: 0, width: 320, height: 180),
+            playerVars: [
+                .playsInline(true),
+                .videoID(currentSong ?? ""),
+                .loopVideo(true),
+                .showRelatedVideo(false),
+                .autoplay(false)
+            ])
+        
+        player.delegate = self
+        let playerPath = PlayerFeatureResources.bundle.path(forResource: "YoutubePlayer", ofType: "html")!
+        let htmlString = (try? String(contentsOfFile: playerPath, encoding: .utf8)) ?? ""
+        player.loadPlayerHTML(htmlString)
+        
+        
+    }
+    
+}
+
+// MARK: YouTubePlayer 컨트롤과 관련된 메소드들을 모아놓은 익스텐션입니다.
+extension PlayState {
+    
+    /// ⏯️ 현재 곡 재생
+    func play() {
+        guard currentSong != nil else { return }
+        self.player.playVideo()
+    }
+    
+    /// ▶️ 해당 곡 새로 재생
+    func load(at song: String) {
+        currentSong = song
+        guard let currentSong = currentSong else { return }
+        self.player.loadVideo(videoID: currentSong)
+    }
+    
+    /// ⏸️ 일시정지
+    func pause() {
+        self.player.pauseVideo()
+    }
+
+    /// ⏩ 다음 곡으로 변경 후 재생
+    func forWard() {
+        self.playList.next()
+        self.currentSong = playList.current
+        play()
+    }
+
+    /// ⏪ 이전 곡으로 변경 후 재생
+    func backWard() {
+        self.playList.back()
+        self.currentSong = playList.current
+        play()
+    }
+
+    /// ♻️ 첫번째 곡으로 변경 후 재생
+    func playAgain() {
+        self.playList.currentPlayIndex = 0
+        currentSong = playList.first
+        play()
+    }
+
+}
+
+// MARK: 커스텀 타입들을 모아놓은 익스텐션입니다.
+extension PlayState {
+    public class PlayList {
+        var list: [String]
+        var currentPlayIndex: Int // 현재 재생중인 노래 인덱스 번호
+
+        init() {
+            list = [String]()
+            currentPlayIndex = 0
+        }
+
+        var first: String? { return list.first }
+        var last: String? { return list.last }
+        var current: String? { return list[currentPlayIndex] }
+        var count: Int { return list.count }
+        var lastIndex: Int { return list.count - 1 }
+        var isEmpty: Bool { return list.isEmpty }
+        var isLast: Bool { return currentPlayIndex == lastIndex }
+
+        func append(_ item: String) {
+            list.append(item)
+        }
+
+        func removeAll() {
+            list.removeAll()
+        }
+
+        func contains(_ item: String) -> Bool {
+            return list.contains(item)
+        }
+
+        func back() {
+            if currentPlayIndex == 0 { currentPlayIndex = lastIndex; return } // 현재 곡이 첫번째 곡이면 마지막 곡으로
+            currentPlayIndex -= 1
+        }
+
+        func next() {
+            if isLast { currentPlayIndex = 0; return } // 현재 곡이 마지막이면 첫번째 곡으로
+            currentPlayIndex += 1
+        }
+
+        func uniqueAppend(item: String) {
+            let uniqueIndex = uniqueIndex(of: item)
+
+            if let uniqueIndex = uniqueIndex {
+                self.currentPlayIndex = uniqueIndex
+            } else { // 재생 목록에 없으면
+                list.append(item) // 재생목록에 추가
+                self.currentPlayIndex = self.lastIndex // index를 가장 마지막으로 옮김
+            }
+        }
+
+        private func uniqueIndex(of item: String) -> Int? {
+            // 해당 곡이 이미 재생목록에 있으면 재생목록 속 해당 곡의 index, 없으면 nil 리턴
+            let index = list.enumerated().compactMap { $0.element == item ? $0.offset : nil }.first
+            return index
+        }
+
+    }
+    
+    public struct PlayProgress {
+        var currentProgress: Double = 0
+        var endProgress: Double = 0
+    }
+}
+
+extension PlayState: YTSwiftyPlayerDelegate {
+    public func player(_ player: YTSwiftyPlayer, didChangeState state: YTSwiftyPlayerState) {
+        print("new state:", state)
+        self.state = state
+    }
+    
+    public func player(_ player: YTSwiftyPlayer, didChangeQuality quality: YTSwiftyVideoQuality) {
+        
+    }
+    
+    public func player(_ player: YTSwiftyPlayer, didReceiveError error: YTSwiftyPlayerError) {
+        
+    }
+    
+    public func player(_ player: YTSwiftyPlayer, didUpdateCurrentTime currentTime: Double) {
+        self.progress.currentProgress = currentTime
+    }
+    
+    public func player(_ player: YTSwiftyPlayer, didChangePlaybackRate playbackRate: Double) {
+        
+    }
+    
+    public func playerReady(_ player: YTSwiftyPlayer) {
+        
+    }
+    
+    public func apiDidChange(_ player: YTSwiftyPlayer) {
+        print("apiDidChange")
+    }
+    
+    public func youtubeIframeAPIReady(_ player: YTSwiftyPlayer) {
+        
+    }
+    
+    public func youtubeIframeAPIFailedToLoad(_ player: YTSwiftyPlayer) {
+        
+    }
+}

--- a/Projects/Features/PlayerFeature/Sources/ViewControllers/PlayerViewController.swift
+++ b/Projects/Features/PlayerFeature/Sources/ViewControllers/PlayerViewController.swift
@@ -54,7 +54,7 @@ public class PlayerViewController: UIViewController {
             frame: .init(x: 0, y: 0, width: 320, height: 180),
             playerVars: [
                 .playsInline(true),
-                .videoID("PVRkT5ZvXLU"),
+                .videoID("wSG93VZoMFg"),
                 .loopVideo(true),
                 .showRelatedVideo(false),
                 .autoplay(true)
@@ -63,7 +63,9 @@ public class PlayerViewController: UIViewController {
         player.delegate = self
         self.youtubePlayerView.addSubview(player)
         
-        player.loadPlayerHTML(playerHtml)
+        let playerPath = PlayerFeatureResources.bundle.path(forResource: "YoutubePlayer", ofType: "html")!
+        let htmlString = (try? String(contentsOfFile: playerPath, encoding: .utf8)) ?? ""
+        player.loadPlayerHTML(htmlString)
     }
     
 }
@@ -98,8 +100,8 @@ private extension PlayerViewController {
             .asDriver(onErrorJustReturn: false)
             .filter { $0 }
             .drive(onNext: { [weak self] _ in
-                print("didPlay")
-                self?.player.loadVideo(videoID: "dfcztPNevwg")
+                guard let self = self else { return }
+                self.player.playerState == .playing ? self.player.pauseVideo() : self.player.playVideo()
             })
             .disposed(by: disposeBag)
 

--- a/Projects/Features/PlayerFeature/Sources/ViewControllers/PlayerViewController.swift
+++ b/Projects/Features/PlayerFeature/Sources/ViewControllers/PlayerViewController.swift
@@ -18,7 +18,7 @@ import YoutubeKit
 public class PlayerViewController: UIViewController {
     private let disposeBag = DisposeBag()
     var viewModel = PlayerViewModel()
-    private var youtubePlayer: YTSwiftyPlayer!
+    private var player: YTSwiftyPlayer!
     var playerView: PlayerView!
     var miniPlayerView: MiniPlayerView!
     
@@ -44,13 +44,13 @@ public class PlayerViewController: UIViewController {
     public override func viewDidLoad() {
         super.viewDidLoad()
         print("viewDidLoad")
-        setupYoutubePlayer()
+        configureYoutubePlayer()
         bindViewModel()
         bindUI()
     }
     
-    func setupYoutubePlayer() {
-        self.youtubePlayer = YTSwiftyPlayer(
+    func configureYoutubePlayer() {
+        self.player = YTSwiftyPlayer(
             frame: .init(x: 0, y: 0, width: 320, height: 180),
             playerVars: [
                 .playsInline(true),
@@ -60,10 +60,10 @@ public class PlayerViewController: UIViewController {
                 .autoplay(true)
             ])
         
-        youtubePlayer.delegate = self
-        self.youtubePlayerView.addSubview(youtubePlayer)
+        player.delegate = self
+        self.youtubePlayerView.addSubview(player)
         
-        youtubePlayer.loadPlayerHTML(playerHtml)
+        player.loadPlayerHTML(playerHtml)
     }
     
 }
@@ -99,7 +99,7 @@ private extension PlayerViewController {
             .filter { $0 }
             .drive(onNext: { [weak self] _ in
                 print("didPlay")
-                self?.youtubePlayer.loadVideo(videoID: "dfcztPNevwg")
+                self?.player.loadVideo(videoID: "dfcztPNevwg")
             })
             .disposed(by: disposeBag)
 

--- a/Projects/Features/PlayerFeature/Sources/ViewControllers/PlayerViewController.swift
+++ b/Projects/Features/PlayerFeature/Sources/ViewControllers/PlayerViewController.swift
@@ -13,7 +13,6 @@ import SnapKit
 import Then
 import RxCocoa
 import RxSwift
-//import YoutubeKit
 
 public class PlayerViewController: UIViewController {
     private let disposeBag = DisposeBag()
@@ -101,6 +100,25 @@ private extension PlayerViewController {
                 print("didClose")
             })
             .disposed(by: disposeBag)
+        
+        output.didPrev
+            .asDriver(onErrorJustReturn: false)
+            .filter { $0 }
+            .drive(onNext: { [weak self] _ in
+                guard let self = self else { return }
+                self.playState.backWard()
+            })
+            .disposed(by: disposeBag)
+        
+        output.didNext
+            .asDriver(onErrorJustReturn: false)
+            .filter { $0 }
+            .drive(onNext: { [weak self] _ in
+                guard let self = self else { return }
+                self.playState.forWard()
+            })
+            .disposed(by: disposeBag)
+        
     }
     
     private func bindUI() {

--- a/Projects/Features/PlayerFeature/Sources/ViewControllers/PlayerViewController.swift
+++ b/Projects/Features/PlayerFeature/Sources/ViewControllers/PlayerViewController.swift
@@ -7,7 +7,6 @@
 //
 
 import UIKit
-import SwiftUI
 import Utility
 import DesignSystem
 import SnapKit
@@ -18,65 +17,30 @@ import YoutubeKit
 
 public class PlayerViewController: UIViewController {
     private let disposeBag = DisposeBag()
-    //private var anyCancellable = Set<AnyCancellable>()
     var viewModel = PlayerViewModel()
-//    var youtubePlayer: YouTubePlayer?
     private var youtubePlayer: YTSwiftyPlayer!
     var playerView: PlayerView!
     var miniPlayerView: MiniPlayerView!
     
-    var youtubePlayerView = UIView()
-    let htmlStr = """
-    <!DOCTYPE html>
-    <html>
-    <head>
-        <style>
-            html, body { margin: 0; padding: 0; width: 100%; height: 100%; background-color: #000000; }
-        </style>
-    </head>
-    <body>
-        <div id="player"></div>
-        <div id="explain"></div>
-        <script src="https://www.youtube.com/iframe_api" onerror="webkit.messageHandlers.onYouTubeIframeAPIFailedToLoad.postMessage('')"></script>
-        <script>
-            var player;
-            var time;
-            YT.ready(function() {
-                     player = new YT.Player('player', %@);
-                     webkit.messageHandlers.onYouTubeIframeAPIReady.postMessage('');
-                     function updateTime() {
-                         var state = player.getPlayerState();
-                         if (state == YT.PlayerState.PLAYING) {
-                            time = player.getCurrentTime();
-                            webkit.messageHandlers.onUpdateCurrentTime.postMessage(time);
-                         }
-                     }
-                     window.setInterval(updateTime, 500);
-                     });
-                     function onReady(event) {
-                         webkit.messageHandlers.onReady.postMessage('');
-                     }
-        function onStateChange(event) {
-            webkit.messageHandlers.onStateChange.postMessage(event.data);
+    var youtubePlayerView = UIView().then {
+        $0.isHidden = false
+    }
+    
+    public override func loadView() {
+        super.loadView()
+        playerView = PlayerView(frame: self.view.frame)
+        miniPlayerView = MiniPlayerView(frame: self.view.frame)
+        miniPlayerView.layer.opacity = 0
+        self.view.addSubview(playerView)
+        self.view.addSubview(miniPlayerView)
+        self.view.addSubview(youtubePlayerView)
+        self.youtubePlayerView.snp.makeConstraints {
+            $0.centerX.centerY.equalTo(self.playerView.thumbnailImageView)
+            $0.width.equalTo(320)
+            $0.height.equalTo(180)
         }
-        function onPlaybackQualityChange(event) {
-            webkit.messageHandlers.onPlaybackQualityChange.postMessage(event.data);
-        }
-        function onPlaybackRateChange(event) {
-            webkit.messageHandlers.onPlaybackRateChange.postMessage(event.data);
-        }
-        function onError(event) {
-            webkit.messageHandlers.onError.postMessage(event.data);
-        }
-        function onApiChange(event) {
-            webkit.messageHandlers.onApiChange.postMessage(event.data);
-        }
-        </script>
-    </body>
-    </html>
-
-    """
-
+    }
+    
     public override func viewDidLoad() {
         super.viewDidLoad()
         print("viewDidLoad")
@@ -86,106 +50,69 @@ public class PlayerViewController: UIViewController {
     }
     
     func setupYoutubePlayer() {
-        //        let configuration = YouTubePlayer.Configuration(
-        //            autoPlay: true,
-        //            showControls: false,
-        //            loopEnabled: true,
-        //            showRelatedVideos: false
-        //        )
-        //
-        //        self.youtubePlayer = YouTubePlayer(
-        //            source: .video(id: "fgSXAKsq-Vo"),
-        //            configuration: configuration
-        //        )
+        self.youtubePlayer = YTSwiftyPlayer(
+            frame: .init(x: 0, y: 0, width: 320, height: 180),
+            playerVars: [
+                .playsInline(true),
+                .videoID("PVRkT5ZvXLU"),
+                .loopVideo(true),
+                .showRelatedVideo(false),
+                .autoplay(true)
+            ])
         
-        //        guard var youtubePlayer = self.youtubePlayer else { return }
+        youtubePlayer.delegate = self
+        self.youtubePlayerView.addSubview(youtubePlayer)
         
-        //        self.youtubePlayerView = YouTubePlayerHostingView(player: youtubePlayer)
-        
-        self.view.addSubview(self.youtubePlayerView)
-        
-//        self.youtubePlayerView.snp.makeConstraints {
-//            $0.centerX.centerY.equalTo(self.playerView.thumbnailImageView)
-//            $0.width.equalTo(320)
-//            $0.height.equalTo(180)
-//        }
-//        self.youtubePlayerView.isHidden = true
-//        self.youtubePlayer = YTSwiftyPlayer(
-//            frame: .init(x: 0, y: 0, width: 320, height: 190),
-//            playerVars: [
-//                .playsInline(true),
-//                .loopVideo(true),
-//                .showRelatedVideo(false),
-//                .autoplay(true)
-//            ])
-//        self.youtubePlayerView.addSubview(youtubePlayer)
-//        youtubePlayer.delegate = self
-//        // Load video player
-//        let playerPath = YoutubeKitResources.bundle
-//            .path(forResource: "player", ofType: "html")!
-//        let htmlString = (try? String(contentsOfFile: playerPath, encoding: .utf8)) ?? ""
-//        self.youtubePlayer.loadVideo(videoID: "fgSXAKsq-Vo")
-
-//        youtubePlayer.loadPlayerHTML(htmlStr)
-//        youtubePlayer.loadDefaultPlayer()
-
+        youtubePlayer.loadPlayerHTML(playerHtml)
     }
     
 }
 
 public extension PlayerViewController {
     func updateOpacity(value: Float) {
-//        playerView.layer.opacity = value
-//        miniPlayerView.layer.opacity = 1 - value
+        playerView.layer.opacity = value
+        miniPlayerView.layer.opacity = 1 - value
     }
 }
 
 private extension PlayerViewController {
     private func bindViewModel() {
-//        let input = PlayerViewModel.Input(
-//            viewWillAppearEvent: self.rx.methodInvoked(#selector(UIViewController.viewWillAppear)).map {_ in },
-//            closeButtonDidTapEvent: self.playerView.closeButton.rx.tap.asObservable(),
-//            playButtonDidTapEvent: self.playerView.playButton.rx.tap.asObservable(),
-//            prevButtonDidTapEvent: self.playerView.prevButton.rx.tap.asObservable(),
-//            nextButtonDidTapEvent: self.playerView.nextButton.rx.tap.asObservable(),
-//            repeatButtonDidTapEvent: self.playerView.repeatButton.rx.tap.asObservable(),
-//            shuffleButtonDidTapEvent: self.playerView.shuffleButton.rx.tap.asObservable(),
-//            likeButtonDidTapEvent: self.playerView.likeButton.rx.tap.asObservable(),
-//            addPlaylistButtonDidTapEvent: self.playerView.addPlayistButton.rx.tap.asObservable(),
-//            playlistButtonDidTapEvent: self.playerView.playistButton.rx.tap.asObservable(),
-//            miniExtendButtonDidTapEvent: self.miniPlayerView.extendButton.rx.tap.asObservable(),
-//            miniPlayButtonDidTapEvent: self.miniPlayerView.playButton.rx.tap.asObservable(),
-//            miniCloseButtonDidTapEvent: self.miniPlayerView.closeButton.rx.tap.asObservable()
-//        )
-//        let output = self.viewModel.transform(from: input)
-//
-//        output.didPlay
-//            .asDriver(onErrorJustReturn: false)
-//            .filter { $0 }
-//            .drive(onNext: { [weak self] _ in
-//                print("didPlay")
-//                self?.youtubePlayer.loadVideo(videoID: "dfcztPNevwg")
-//            })
-//            .disposed(by: disposeBag)
-//
-//        output.didClose
-//            .asDriver(onErrorJustReturn: false)
-//            .filter { $0 }
-//            .drive(onNext: { [weak self] _ in
-//                print("didClose")
-//            })
-//            .disposed(by: disposeBag)
+        let input = PlayerViewModel.Input(
+            viewWillAppearEvent: self.rx.methodInvoked(#selector(UIViewController.viewWillAppear)).map {_ in },
+            closeButtonDidTapEvent: self.playerView.closeButton.rx.tap.asObservable(),
+            playButtonDidTapEvent: self.playerView.playButton.rx.tap.asObservable(),
+            prevButtonDidTapEvent: self.playerView.prevButton.rx.tap.asObservable(),
+            nextButtonDidTapEvent: self.playerView.nextButton.rx.tap.asObservable(),
+            repeatButtonDidTapEvent: self.playerView.repeatButton.rx.tap.asObservable(),
+            shuffleButtonDidTapEvent: self.playerView.shuffleButton.rx.tap.asObservable(),
+            likeButtonDidTapEvent: self.playerView.likeButton.rx.tap.asObservable(),
+            addPlaylistButtonDidTapEvent: self.playerView.addPlayistButton.rx.tap.asObservable(),
+            playlistButtonDidTapEvent: self.playerView.playistButton.rx.tap.asObservable(),
+            miniExtendButtonDidTapEvent: self.miniPlayerView.extendButton.rx.tap.asObservable(),
+            miniPlayButtonDidTapEvent: self.miniPlayerView.playButton.rx.tap.asObservable(),
+            miniCloseButtonDidTapEvent: self.miniPlayerView.closeButton.rx.tap.asObservable()
+        )
+        let output = self.viewModel.transform(from: input)
+
+        output.didPlay
+            .asDriver(onErrorJustReturn: false)
+            .filter { $0 }
+            .drive(onNext: { [weak self] _ in
+                print("didPlay")
+                self?.youtubePlayer.loadVideo(videoID: "dfcztPNevwg")
+            })
+            .disposed(by: disposeBag)
+
+        output.didClose
+            .asDriver(onErrorJustReturn: false)
+            .filter { $0 }
+            .drive(onNext: { [weak self] _ in
+                print("didClose")
+            })
+            .disposed(by: disposeBag)
     }
     
     private func bindUI() {
-//        self.playerView.playButton.rx.tap.bind { _ in
-//            print("clicked")
-//            //self.youtubePlayer.load(source: .video(id: "1hcdQixxJdA"))
-//
-//           // self.youtubePlayer.play()
-//        }.disposed(by: disposeBag)
-        
-       // self.youtubePlayer.$source.sink { print($0?.id) }.store(in: &anyCancellable)
 
     }
 }

--- a/Projects/Features/PlayerFeature/Sources/ViewControllers/PlayerViewController.swift
+++ b/Projects/Features/PlayerFeature/Sources/ViewControllers/PlayerViewController.swift
@@ -13,12 +13,12 @@ import SnapKit
 import Then
 import RxCocoa
 import RxSwift
-import YoutubeKit
+//import YoutubeKit
 
 public class PlayerViewController: UIViewController {
     private let disposeBag = DisposeBag()
     var viewModel = PlayerViewModel()
-    private var player: YTSwiftyPlayer!
+    let playState = PlayState.shared
     var playerView: PlayerView!
     var miniPlayerView: MiniPlayerView!
     
@@ -39,33 +39,14 @@ public class PlayerViewController: UIViewController {
             $0.width.equalTo(320)
             $0.height.equalTo(180)
         }
+        self.youtubePlayerView.addSubview(playState.player)
     }
     
     public override func viewDidLoad() {
         super.viewDidLoad()
         print("viewDidLoad")
-        configureYoutubePlayer()
         bindViewModel()
         bindUI()
-    }
-    
-    func configureYoutubePlayer() {
-        self.player = YTSwiftyPlayer(
-            frame: .init(x: 0, y: 0, width: 320, height: 180),
-            playerVars: [
-                .playsInline(true),
-                .videoID("wSG93VZoMFg"),
-                .loopVideo(true),
-                .showRelatedVideo(false),
-                .autoplay(true)
-            ])
-        
-        player.delegate = self
-        self.youtubePlayerView.addSubview(player)
-        
-        let playerPath = PlayerFeatureResources.bundle.path(forResource: "YoutubePlayer", ofType: "html")!
-        let htmlString = (try? String(contentsOfFile: playerPath, encoding: .utf8)) ?? ""
-        player.loadPlayerHTML(htmlString)
     }
     
 }
@@ -101,7 +82,15 @@ private extension PlayerViewController {
             .filter { $0 }
             .drive(onNext: { [weak self] _ in
                 guard let self = self else { return }
-                self.player.playerState == .playing ? self.player.pauseVideo() : self.player.playVideo()
+                if self.playState.state == .playing {
+                    self.playState.pause()
+                    self.playerView.playButton.setImage(DesignSystemAsset.Player.playLarge.image, for: .normal)
+                    self.miniPlayerView.playButton.setImage(DesignSystemAsset.Player.miniPlay.image, for: .normal)
+                } else {
+                    self.playState.play()
+                    self.playerView.playButton.setImage(DesignSystemAsset.Player.pause.image, for: .normal)
+                    self.miniPlayerView.playButton.setImage(DesignSystemAsset.Player.miniPause.image, for: .normal)
+                }
             })
             .disposed(by: disposeBag)
 
@@ -118,42 +107,3 @@ private extension PlayerViewController {
 
     }
 }
-
-extension PlayerViewController: YTSwiftyPlayerDelegate {
-    public func player(_ player: YTSwiftyPlayer, didChangeState state: YTSwiftyPlayerState) {
-        
-    }
-    
-    public func player(_ player: YTSwiftyPlayer, didChangeQuality quality: YTSwiftyVideoQuality) {
-        
-    }
-    
-    public func player(_ player: YTSwiftyPlayer, didReceiveError error: YTSwiftyPlayerError) {
-        
-    }
-    
-    public func player(_ player: YTSwiftyPlayer, didUpdateCurrentTime currentTime: Double) {
-        
-    }
-    
-    public func player(_ player: YTSwiftyPlayer, didChangePlaybackRate playbackRate: Double) {
-        
-    }
-    
-    public func playerReady(_ player: YTSwiftyPlayer) {
-        
-    }
-    
-    public func apiDidChange(_ player: YTSwiftyPlayer) {
-        
-    }
-    
-    public func youtubeIframeAPIReady(_ player: YTSwiftyPlayer) {
-        
-    }
-    
-    public func youtubeIframeAPIFailedToLoad(_ player: YTSwiftyPlayer) {
-        
-    }
-}
-

--- a/Projects/Features/PlayerFeature/Sources/ViewModels/PlayerViewModel.swift
+++ b/Projects/Features/PlayerFeature/Sources/ViewModels/PlayerViewModel.swift
@@ -40,6 +40,8 @@ final class PlayerViewModel: ViewModelType {
         var viewsCountText = BehaviorRelay<String>(value: "")
         var didPlay = PublishRelay<Bool>()
         var didClose = PublishRelay<Bool>()
+        var didPrev = PublishRelay<Bool>()
+        var didNext = PublishRelay<Bool>()
     }
     
     private let useCase: PlayerUseCase
@@ -70,11 +72,11 @@ final class PlayerViewModel: ViewModelType {
         }.disposed(by: disposeBag)
         
         input.prevButtonDidTapEvent.subscribe { _ in
-            
+            output.didPrev.accept(true)
         }.disposed(by: disposeBag)
         
         input.nextButtonDidTapEvent.subscribe { _ in
-            
+            output.didNext.accept(true)
         }.disposed(by: disposeBag)
         
         return output

--- a/Projects/Features/PlayerFeature/Sources/ViewModels/PlayerViewModel.swift
+++ b/Projects/Features/PlayerFeature/Sources/ViewModels/PlayerViewModel.swift
@@ -69,6 +69,14 @@ final class PlayerViewModel: ViewModelType {
             output.didClose.accept(true)
         }.disposed(by: disposeBag)
         
+        input.prevButtonDidTapEvent.subscribe { _ in
+            
+        }.disposed(by: disposeBag)
+        
+        input.nextButtonDidTapEvent.subscribe { _ in
+            
+        }.disposed(by: disposeBag)
+        
         return output
     }
 }


### PR DESCRIPTION
## 개요
라이브러리 변경 및 combine 임포트 문제로 팀원들이 주석처리하여 사용중이었습니다.
코드수정을 통해 불필요한 주석처리를 피하고자 했습니다.

## 작업사항
PlayState 싱글톤 객체를 만듭니다.
PlayState 는 public 으로 앱 전체에서 접근이 가능하도록 하며, 멤버 변수마다 접근제어자를 다르게 두어 몇몇 멤버에 한해선 접근이 불가능하도록 합니다.

(앱 전체 <-> PlayState <-> Player  와 같은 형태로 구상중입니다.)

재생/일시정지, 이전곡, 다음곡 기능을 추가합니다.

Closes #15 