### PR TITLE
🔀 :: 편집모드 진입 시 애니메이션 수정 및 좋아요 버튼 UI, UIView tapPublisher 구현

### DIFF
--- a/Projects/Features/PlayerFeature/Sources/ViewControllers/PlayerViewController.swift
+++ b/Projects/Features/PlayerFeature/Sources/ViewControllers/PlayerViewController.swift
@@ -95,9 +95,9 @@ private extension PlayerViewController {
             sliderValueChangedEvent: self.playerView.playTimeSlider.rx.value.changed.asObservable(),
             repeatButtonDidTapEvent: self.playerView.repeatButton.rx.tap.asObservable(),
             shuffleButtonDidTapEvent: self.playerView.shuffleButton.rx.tap.asObservable(),
-            likeButtonDidTapEvent: self.playerView.likeButton.rx.tap.asObservable(),
-            addPlaylistButtonDidTapEvent: self.playerView.addPlayistButton.rx.tap.asObservable(),
-            playlistButtonDidTapEvent: self.playerView.playistButton.tapPublisher,
+            likeButtonDidTapEvent: self.playerView.likeButton.tapPublisher(),
+            addPlaylistButtonDidTapEvent: self.playerView.addPlayistButton.tapPublisher(),
+            playlistButtonDidTapEvent: self.playerView.playistButton.tapPublisher(),
             miniExtendButtonDidTapEvent: self.miniPlayerView.extendButton.rx.tap.asObservable(),
             miniPlayButtonDidTapEvent: self.miniPlayerView.playButton.rx.tap.asObservable(),
             miniCloseButtonDidTapEvent: self.miniPlayerView.closeButton.rx.tap.asObservable()
@@ -169,13 +169,13 @@ private extension PlayerViewController {
     private func bindlikes(output: PlayerViewModel.Output) {
         output.likeCountText.sink { [weak self] likeCountText in
             guard let self else { return }
-            self.playerView.likeButton.setTitle(likeCountText, for: .normal)
+            self.playerView.likeButton.title = likeCountText
         }
         .store(in: &subscription)
         
         output.likeState.sink { [weak self] isLiked in
             guard let self else { return }
-            self.playerView.likeButton.isOn = isLiked
+            self.playerView.likeButton.isLiked = isLiked
         }.store(in: &subscription)
     }
     

--- a/Projects/Features/PlayerFeature/Sources/ViewControllers/PlayerViewController.swift
+++ b/Projects/Features/PlayerFeature/Sources/ViewControllers/PlayerViewController.swift
@@ -182,7 +182,7 @@ private extension PlayerViewController {
     private func bindViews(output: PlayerViewModel.Output) {
         output.viewsCountText.sink { [weak self] viewsCountText in
             guard let self else { return }
-            self.playerView.viewsLabel.text = viewsCountText
+            self.playerView.viewsView.title = viewsCountText
         }
         .store(in: &subscription)
     }

--- a/Projects/Features/PlayerFeature/Sources/ViewControllers/PlaylistViewController.swift
+++ b/Projects/Features/PlayerFeature/Sources/ViewControllers/PlaylistViewController.swift
@@ -77,7 +77,6 @@ private extension PlaylistViewController {
             self.playlistView.editButton.setColor(isHighlight: isEditing)
             self.playlistView.playlistTableView.setEditing(isEditing, animated: true)
             self.playlistView.playlistTableView.visibleCells.forEach { $0.isEditing = isEditing }
-            
         }.store(in: &subscription)
         
         output.currentSongIndex.sink { [weak self] _ in

--- a/Projects/Features/PlayerFeature/Sources/ViewModels/PlayerViewModel.swift
+++ b/Projects/Features/PlayerFeature/Sources/ViewModels/PlayerViewModel.swift
@@ -25,8 +25,8 @@ final class PlayerViewModel: ViewModelType {
         let sliderValueChangedEvent: Observable<Float>
         let repeatButtonDidTapEvent: Observable<Void>
         let shuffleButtonDidTapEvent: Observable<Void>
-        let likeButtonDidTapEvent: Observable<Void>
-        let addPlaylistButtonDidTapEvent: Observable<Void>
+        let likeButtonDidTapEvent: AnyPublisher<Void, Never>
+        let addPlaylistButtonDidTapEvent: AnyPublisher<Void, Never>
         let playlistButtonDidTapEvent: AnyPublisher<Void, Never>
         let miniExtendButtonDidTapEvent: Observable<Void>
         let miniPlayButtonDidTapEvent: Observable<Void>

--- a/Projects/Features/PlayerFeature/Sources/ViewModels/PlaylistViewModel.swift
+++ b/Projects/Features/PlayerFeature/Sources/ViewModels/PlaylistViewModel.swift
@@ -26,7 +26,7 @@ final class PlaylistViewModel: ViewModelType {
     struct Output {
         var playerState = CurrentValueSubject<YouTubePlayer.PlaybackState, Never>(.unstarted)
         var willClosePlaylist = PassthroughSubject<Bool, Never>()
-        var editState = CurrentValueSubject<Bool, Never>(false)
+        var editState = PassthroughSubject<Bool, Never>()
         var thumbnailImageURL = CurrentValueSubject<String, Never>("")
         var playTimeValue = CurrentValueSubject<Float, Never>(0.0)
         var totalTimeValue = CurrentValueSubject<Float, Never>(0.0)

--- a/Projects/Features/PlayerFeature/Sources/Views/LikeButton.swift
+++ b/Projects/Features/PlayerFeature/Sources/Views/LikeButton.swift
@@ -9,12 +9,12 @@
 import UIKit
 import DesignSystem
 
-protocol Toggleable {
-    var isOn: Bool { get set }
+protocol Likeable {
+    var isLiked: Bool { get set }
 }
 
-internal class LikeButton: VerticalButton, Toggleable {
-    var isOn: Bool = false {
+class LikeButton: VerticalImageButton, Likeable {
+    var isLiked: Bool = false {
         didSet {
             setColor()
             setImage()
@@ -22,12 +22,14 @@ internal class LikeButton: VerticalButton, Toggleable {
     }
     
     private func setColor() {
-        let color = isOn ? DesignSystemAsset.PrimaryColor.increase.color : DesignSystemAsset.GrayColor.gray400.color
-        self.setTitleColor(color, for: .normal)
+        let color = isLiked ? DesignSystemAsset.PrimaryColor.increase.color : DesignSystemAsset.GrayColor.gray400.color
+        self.titleLabel.textColor = color
     }
     
     private func setImage() {
-        let image = isOn ? DesignSystemAsset.Player.likeOn.image : DesignSystemAsset.Player.likeOff.image
-        self.setImage(image, for: .normal)
+        let image = isLiked ? DesignSystemAsset.Player.likeOn.image : DesignSystemAsset.Player.likeOff.image
+        self.image = image
     }
+
+    
 }

--- a/Projects/Features/PlayerFeature/Sources/Views/PlayerView.swift
+++ b/Projects/Features/PlayerFeature/Sources/Views/PlayerView.swift
@@ -147,12 +147,9 @@ public final class PlayerView: UIView {
     }
     
     internal lazy var likeButton = LikeButton().then {
-        $0.setImage(DesignSystemAsset.Player.likeOff.image, for: .normal)
-        $0.setTitle("1.1만", for: .normal)
-        $0.titleLabel?.font = UIFont(font: DesignSystemFontFamily.Pretendard.medium, size: 12)
-        $0.titleLabel?.setLineSpacing(kernValue: -0.5, lineHeightMultiple: 0.98)
-        $0.isOn = false
-        $0.alignToVertical()
+        $0.titleLabel.font = UIFont(font: DesignSystemFontFamily.Pretendard.medium, size: 12)
+        $0.titleLabel.setLineSpacing(kernValue: -0.5, lineHeightMultiple: 0.98)
+        $0.isLiked = false
     }
     
     private lazy var viewsView: UIView = UIView()
@@ -168,25 +165,22 @@ public final class PlayerView: UIView {
         $0.textColor = DesignSystemAsset.GrayColor.gray400.color
     }
     
-    internal lazy var addPlayistButton = VerticalButton().then {
-        $0.setImage(DesignSystemAsset.Player.playerMusicAdd.image, for: .normal)
-        $0.setTitle("노래담기", for: .normal)
-        $0.tintColor = .systemGray
-        $0.titleLabel?.font = UIFont(font: DesignSystemFontFamily.Pretendard.medium, size: 12)
-        $0.titleLabel?.setLineSpacing(kernValue: -0.5, lineHeightMultiple: 0.98)
-        $0.setTitleColor(DesignSystemAsset.GrayColor.gray400.color, for: .normal)
-        $0.alignToVertical()
+    internal lazy var addPlayistButton = VerticalImageButton().then {
+        $0.image = DesignSystemAsset.Player.playerMusicAdd.image
+        $0.title = "노래담기"
+        $0.titleLabel.font = UIFont(font: DesignSystemFontFamily.Pretendard.medium, size: 12)
+        $0.titleLabel.setLineSpacing(kernValue: -0.5, lineHeightMultiple: 0.98)
+        $0.titleLabel.textColor = DesignSystemAsset.GrayColor.gray400.color
     }
     
-    internal lazy var playistButton = VerticalButton().then {
-        $0.setImage(DesignSystemAsset.Player.playList.image, for: .normal)
-        $0.setTitle("재생목록", for: .normal)
-        $0.tintColor = .systemGray
-        $0.titleLabel?.font = UIFont(font: DesignSystemFontFamily.Pretendard.medium, size: 12)
-        $0.titleLabel?.setLineSpacing(kernValue: -0.5, lineHeightMultiple: 0.98)
-        $0.setTitleColor(DesignSystemAsset.GrayColor.gray400.color, for: .normal)
-        $0.alignToVertical()
+    internal lazy var playistButton = VerticalImageButton().then {
+        $0.image = DesignSystemAsset.Player.playList.image
+        $0.title = "재생목록"
+        $0.titleLabel.font = UIFont(font: DesignSystemFontFamily.Pretendard.medium, size: 12)
+        $0.titleLabel.setLineSpacing(kernValue: -0.5, lineHeightMultiple: 0.98)
+        $0.titleLabel.textColor = DesignSystemAsset.GrayColor.gray400.color
     }
+    
     
     private var firstSpacing: CGFloat = 0
     private var secondSpacing: CGFloat = 0

--- a/Projects/Features/PlayerFeature/Sources/Views/PlayerView.swift
+++ b/Projects/Features/PlayerFeature/Sources/Views/PlayerView.swift
@@ -152,17 +152,11 @@ public final class PlayerView: UIView {
         $0.isLiked = false
     }
     
-    private lazy var viewsView: UIView = UIView()
-    
-    internal lazy var viewsImageView = UIImageView().then {
+    internal lazy var viewsView = VerticalImageButton().then {
         $0.image = DesignSystemAsset.Player.views.image
-    }
-    
-    internal lazy var viewsLabel = UILabel().then {
-        $0.text = "1.2만"
-        $0.font = .init(font: DesignSystemFontFamily.Pretendard.medium, size: 12)
-        $0.setLineSpacing(kernValue: -0.5, lineHeightMultiple: 0.98)
-        $0.textColor = DesignSystemAsset.GrayColor.gray400.color
+        $0.titleLabel.font = UIFont(font: DesignSystemFontFamily.Pretendard.medium, size: 12)
+        $0.titleLabel.setLineSpacing(kernValue: -0.5, lineHeightMultiple: 0.98)
+        $0.titleLabel.textColor = DesignSystemAsset.GrayColor.gray400.color
     }
     
     internal lazy var addPlayistButton = VerticalImageButton().then {
@@ -247,8 +241,6 @@ private extension PlayerView {
         self.bottomBarStackView.addArrangedSubview(addPlayistButton)
         self.bottomBarStackView.addArrangedSubview(playistButton)
         
-        self.viewsView.addSubview(viewsImageView)
-        self.viewsView.addSubview(viewsLabel)
     }
     
     private func configureBackground() {
@@ -376,14 +368,6 @@ private extension PlayerView {
         bottomBarStackView.snp.makeConstraints {
             $0.top.bottom.equalToSuperview()
             $0.horizontalEdges.equalToSuperview().inset(22)
-        }
-        viewsImageView.snp.makeConstraints {
-            $0.top.equalToSuperview().offset(4)
-            $0.centerX.equalToSuperview()
-        }
-        viewsLabel.snp.makeConstraints {
-            $0.top.equalTo(viewsImageView.snp.bottom)
-            $0.centerX.equalToSuperview()
         }
     }
     

--- a/Projects/Features/PlayerFeature/Sources/Views/PlaylistTableViewCell.swift
+++ b/Projects/Features/PlayerFeature/Sources/Views/PlaylistTableViewCell.swift
@@ -64,7 +64,7 @@ internal class PlaylistTableViewCell: UITableViewCell {
     
     internal var isPlaying: Bool = false {
         didSet {
-            updatePlayingState()
+            updateButtonHidden()
             highlight()
             isPlaying ? waveStreamAnimationView.play() : waveStreamAnimationView.pause()
         }
@@ -72,7 +72,7 @@ internal class PlaylistTableViewCell: UITableViewCell {
     
     override var isEditing: Bool {
         didSet {
-            updatePlayingState()
+            replaceAnimation()
         }
     }
     
@@ -90,29 +90,54 @@ internal class PlaylistTableViewCell: UITableViewCell {
         isPlaying = false
     }
     
-    private func updatePlayingState() {
+    private func updateButtonHidden() {
+        if isEditing {
+            playImageView.isHidden = true
+            waveStreamAnimationView.isHidden = true
+        } else {
+            playImageView.isHidden = isPlaying
+            waveStreamAnimationView.isHidden = !isPlaying
+        }
+    }
+    
+    private func replaceAnimation() {
         if isEditing {
             UIView.animate(withDuration: 0.3) { [weak self] in // 오른쪽으로 사라지는 애니메이션
                 guard let self else { return }
                 self.playImageView.alpha = 0
                 self.playImageView.transform = CGAffineTransform(translationX: 100, y: 0)
+                self.playImageView.snp.updateConstraints {
+                    $0.right.equalTo(self.contentView.snp.right).offset(24)
+                }
                 self.waveStreamAnimationView.alpha = 0
                 self.waveStreamAnimationView.transform = CGAffineTransform(translationX: 100, y: 0)
+                self.waveStreamAnimationView.snp.updateConstraints {
+                    $0.right.equalTo(self.contentView.snp.right).offset(24)
+                }
+                self.layoutIfNeeded()
             } completion: { [weak self] _ in
                 guard let self else { return }
                 self.playImageView.isHidden = true
                 self.waveStreamAnimationView.isHidden = true
             }
         } else {
+            self.playImageView.isHidden = isPlaying
+            self.waveStreamAnimationView.isHidden = !isPlaying
             UIView.animate(withDuration: 0.3) { [weak self] in // 다시 돌아오는 애니메이션
                 guard let self else { return }
                 self.playImageView.alpha = 1
                 self.playImageView.transform = .identity
+                self.playImageView.snp.updateConstraints {
+                    $0.right.equalTo(self.contentView.snp.right).offset(-20)
+                }
                 self.waveStreamAnimationView.alpha = 1
                 self.waveStreamAnimationView.transform = .identity
+                self.waveStreamAnimationView.snp.updateConstraints {
+                    $0.right.equalTo(self.contentView.snp.right).offset(-20)
+                }
+                self.layoutIfNeeded()
             }
-            self.playImageView.isHidden = isPlaying
-            self.waveStreamAnimationView.isHidden = !isPlaying
+            
         }
     }
     
@@ -163,13 +188,13 @@ internal class PlaylistTableViewCell: UITableViewCell {
         playImageView.snp.makeConstraints {
             $0.width.height.equalTo(32)
             $0.centerY.equalTo(contentView.snp.centerY)
-            $0.right.equalTo(contentView.snp.right).offset(-14)
+            $0.right.equalTo(contentView.snp.right).offset(-20)
         }
         
         waveStreamAnimationView.snp.makeConstraints {
             $0.width.height.equalTo(32)
             $0.centerY.equalTo(contentView.snp.centerY)
-            $0.right.equalTo(contentView.snp.right).offset(-14)
+            $0.right.equalTo(contentView.snp.right).offset(-20)
         }
     }
     

--- a/Projects/Features/PlayerFeature/Sources/Views/PlaylistTableViewCell.swift
+++ b/Projects/Features/PlayerFeature/Sources/Views/PlaylistTableViewCell.swift
@@ -66,6 +66,7 @@ internal class PlaylistTableViewCell: UITableViewCell {
         didSet {
             updatePlayingState()
             highlight()
+            isPlaying ? waveStreamAnimationView.play() : waveStreamAnimationView.pause()
         }
     }
     

--- a/Projects/Features/PlayerFeature/Sources/Views/VerticalImageButton.swift
+++ b/Projects/Features/PlayerFeature/Sources/Views/VerticalImageButton.swift
@@ -1,0 +1,49 @@
+//
+//  VerticalImageButton.swift
+//  PlayerFeature
+//
+//  Created by YoungK on 2023/03/20.
+//  Copyright © 2023 yongbeomkwak. All rights reserved.
+//
+
+import UIKit
+import SnapKit
+
+internal class VerticalImageButton: UIView {
+    let imageView = UIImageView()
+    let titleLabel = UILabel()
+    
+    var title: String? {
+        didSet {
+            titleLabel.text = title
+        }
+    }
+    
+    var image: UIImage? {
+        didSet {
+            imageView.image = image
+        }
+    }
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        addSubview(imageView)
+        addSubview(titleLabel)
+        
+        imageView.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.top.equalToSuperview().offset(4)
+            $0.width.height.equalTo(32)
+        }
+        
+        titleLabel.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.top.equalTo(imageView.snp.bottom)
+        }
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/Projects/Modules/Utility/Sources/Extensions/Extension+UITapGesutreRecognizer.swift
+++ b/Projects/Modules/Utility/Sources/Extensions/Extension+UITapGesutreRecognizer.swift
@@ -1,0 +1,60 @@
+//
+//  Extension+UITapGesutreRecognizer.swift
+//  Utility
+//
+//  Created by YoungK on 2023/03/20.
+//  Copyright © 2023 yongbeomkwak. All rights reserved.
+//
+
+import Foundation
+import UIKit
+import Combine
+
+/// UIControl 을 상속받지 않는 UIView 등의 이벤트를 Combine 으로 처리하기 위한 Publisher 입니다.
+public extension UITapGestureRecognizer {
+    struct GesturePublisher<TapRecognizer: UITapGestureRecognizer>: Publisher {
+        public typealias Output = TapRecognizer
+        public typealias Failure = Never
+        
+        private let recognizer: TapRecognizer
+        private let view: UIView
+        
+        init(recognizer: TapRecognizer, view: UIView) {
+            self.recognizer = recognizer
+            self.view = view
+        }
+        
+        public func receive<S>(subscriber: S) where S : Subscriber, Never == S.Failure, TapRecognizer == S.Input {
+            let subscription = GestureSubscription(
+                subscriber: subscriber,
+                recognizer: recognizer,
+                view: view
+            )
+            subscriber.receive(subscription: subscription)
+        }
+        
+    }
+    
+    final class GestureSubscription<S: Subscriber, TapRecognizer: UITapGestureRecognizer>: Subscription where S.Input == TapRecognizer {
+        private var subscriber: S?
+        private let recognizer: TapRecognizer
+        
+        init(subscriber: S, recognizer: TapRecognizer, view: UIView) {
+            self.subscriber = subscriber
+            self.recognizer = recognizer
+            recognizer.addTarget(self, action: #selector(eventHandler))
+            view.addGestureRecognizer(recognizer)
+        }
+        
+        public func request(_ demand: Subscribers.Demand) {}
+        
+        public func cancel() {
+            subscriber = nil
+        }
+        
+        @objc func eventHandler() {
+            _ = subscriber?.receive(recognizer)
+        }
+        
+    }
+}

--- a/Projects/Modules/Utility/Sources/Extensions/Extension+UIView.swift
+++ b/Projects/Modules/Utility/Sources/Extensions/Extension+UIView.swift
@@ -9,42 +9,57 @@
 import Foundation
 import UIKit
 import SwiftEntryKit
+import Combine
 
 public extension UIView {
     
     enum VerticalLocation {
-           case bottom
-           case top
-           case left
-           case right
-       }
-
-       func addShadow(location: VerticalLocation, color: UIColor = .black, opacity: Float = 0.8, radius: CGFloat = 5.0) {
-           switch location {
-           case .bottom:
-                addShadow(offset: CGSize(width: 0, height: 10), color: color, opacity: opacity, radius: radius)
-           case .top:
-               addShadow(offset: CGSize(width: 0, height: -10), color: color, opacity: opacity, radius: radius)
-           case .left:
-               addShadow(offset: CGSize(width: -10, height: 0), color: color, opacity: opacity, radius: radius)
-           case .right:
-               addShadow(offset: CGSize(width: 10, height: 0), color: color, opacity: opacity, radius: radius)
-           }
-       }
-
-       func addShadow(offset: CGSize, color: UIColor = .black, opacity: Float = 0.1, radius: CGFloat = 3.0) {
-           
-           /// 테두리 밖으로 contents가 있을 때, 마스킹(true)하여 표출안되게 할것인지 마스킹을 off(false  emptyView.layer.masksToBounds = false
-           /// shadow 색상
-           /// 현재 shadow는 view의 layer 테두리와 동일한 위치로 있는 상태이므로 offset을 통해 그림자를 이동시켜야 표출
-           /// shadow의 투명도 (0 ~ 1)
-           /// shadow의 corner radius
-           self.layer.masksToBounds = false
-           self.layer.shadowColor = color.cgColor
-           self.layer.shadowOffset = offset
-           self.layer.shadowOpacity = opacity
-           self.layer.shadowRadius = radius
-       }
+        case bottom
+        case top
+        case left
+        case right
+    }
+    
+    func tapPublisher() -> AnyPublisher<UITapGestureRecognizer, Never> {
+        return UITapGestureRecognizer.GesturePublisher(recognizer: .init(), view: self).eraseToAnyPublisher()
+    }
+    
+    /// 1초 이내 첫 이벤트를 제외한 나머지 이벤트는 무시하는 Publisher 입니다.
+    func throttleTapPublisher() -> Publishers.Throttle<UITapGestureRecognizer.GesturePublisher<UITapGestureRecognizer>, RunLoop> {
+        return UITapGestureRecognizer.GesturePublisher(recognizer: .init(), view: self)
+            .throttle(
+                for: .seconds(1),
+                scheduler: RunLoop.main,
+                latest: false
+            )
+    }
+    
+    func addShadow(location: VerticalLocation, color: UIColor = .black, opacity: Float = 0.8, radius: CGFloat = 5.0) {
+        switch location {
+        case .bottom:
+            addShadow(offset: CGSize(width: 0, height: 10), color: color, opacity: opacity, radius: radius)
+        case .top:
+            addShadow(offset: CGSize(width: 0, height: -10), color: color, opacity: opacity, radius: radius)
+        case .left:
+            addShadow(offset: CGSize(width: -10, height: 0), color: color, opacity: opacity, radius: radius)
+        case .right:
+            addShadow(offset: CGSize(width: 10, height: 0), color: color, opacity: opacity, radius: radius)
+        }
+    }
+    
+    func addShadow(offset: CGSize, color: UIColor = .black, opacity: Float = 0.1, radius: CGFloat = 3.0) {
+        
+        /// 테두리 밖으로 contents가 있을 때, 마스킹(true)하여 표출안되게 할것인지 마스킹을 off(false  emptyView.layer.masksToBounds = false
+        /// shadow 색상
+        /// 현재 shadow는 view의 layer 테두리와 동일한 위치로 있는 상태이므로 offset을 통해 그림자를 이동시켜야 표출
+        /// shadow의 투명도 (0 ~ 1)
+        /// shadow의 corner radius
+        self.layer.masksToBounds = false
+        self.layer.shadowColor = color.cgColor
+        self.layer.shadowOffset = offset
+        self.layer.shadowOpacity = opacity
+        self.layer.shadowRadius = radius
+    }
     
     
     func animateSizeDownToUp(timeInterval: TimeInterval) {
@@ -60,7 +75,7 @@ public extension UIView {
         attributes.displayDuration = 2
         attributes.entryBackground = .color(color: EKColor(rgb: 0x101828).with(alpha: 0.8))
         attributes.roundCorners = .all(radius: 20)
-
+        
         let style = EKProperty.LabelStyle(
             font: .systemFont(ofSize: 14, weight: .light),
             color: EKColor(rgb: 0xFCFCFD),
@@ -70,7 +85,7 @@ public extension UIView {
             text: text,
             style: style
         )
-
+        
         let contentView = EKNoteMessageView(with: labelContent)
         contentView.verticalOffset = 10
         SwiftEntryKit.display(entry: contentView, using: attributes)

--- a/Projects/Modules/Utility/Sources/Extensions/Extension+UIView.swift
+++ b/Projects/Modules/Utility/Sources/Extensions/Extension+UIView.swift
@@ -20,18 +20,22 @@ public extension UIView {
         case right
     }
     
-    func tapPublisher() -> AnyPublisher<UITapGestureRecognizer, Never> {
-        return UITapGestureRecognizer.GesturePublisher(recognizer: .init(), view: self).eraseToAnyPublisher()
+    func tapPublisher() -> AnyPublisher<Void, Never> {
+        return UITapGestureRecognizer.GesturePublisher(recognizer: .init(), view: self)
+            .map { _ in }
+            .eraseToAnyPublisher()
     }
     
     /// 1초 이내 첫 이벤트를 제외한 나머지 이벤트는 무시하는 Publisher 입니다.
-    func throttleTapPublisher() -> Publishers.Throttle<UITapGestureRecognizer.GesturePublisher<UITapGestureRecognizer>, RunLoop> {
+    func throttleTapPublisher() -> AnyPublisher<Void, Never> {
         return UITapGestureRecognizer.GesturePublisher(recognizer: .init(), view: self)
             .throttle(
                 for: .seconds(1),
                 scheduler: RunLoop.main,
                 latest: false
             )
+            .map { _ in }
+            .eraseToAnyPublisher()
     }
     
     func addShadow(location: VerticalLocation, color: UIColor = .black, opacity: Float = 0.8, radius: CGFloat = 5.0) {


### PR DESCRIPTION
## 개요
플레이어에서 발생하던 몇가지 버그 및 UI 문제를 수정하고, 
UIView 의 터치이벤트를 Combine으로 제어하기 위해 tapPublisher를 구현하였습니다.

## 작업사항
- 좋아요 버튼을 구현합니다. (커스텀 tapPublisher)
  좋아요 버튼을 UIView 로 구현하면서 이벤트 처리방법을 고민하다가 플레이어에선 Combine을 주로 사용하고 있기에 UIView의 이벤트 또한 
  Combine으로 제어하고 싶었습니다.
  그러나 UIView 는 UIControl을 상속하지 않기에 기존에 UIControl 에 구현해둔 Publisher를 사용할 수 없었습니다.
  UITapGesutreRecognizer 에 Publisher를 구현하여 UIView 를 포함한 UITapGesutreRecognizer 을 상속받는 UI에서도 사용할 수 있도록 하였습니다.
- 편집모드 진입 시 애니메이션을 수정합니다.

### 애니메이션 수정 전
https://user-images.githubusercontent.com/60254939/226572161-3f711bcb-0700-40c0-827f-3be4bf67294a.mov

### 애니메이션 수정 후
https://user-images.githubusercontent.com/60254939/226572270-51034d24-5ebe-46a5-b8a8-fa7980720aaf.mov





Closes #137

