### PR TITLE
🔀  :: PlayList 리팩토링 및 DataSource, PlayList 간의 구조 변경, 각종 버그 수정

### DIFF
--- a/Projects/Features/ArtistFeature/Sources/ViewControllers/ArtistViewController.swift
+++ b/Projects/Features/ArtistFeature/Sources/ViewControllers/ArtistViewController.swift
@@ -7,7 +7,6 @@ import BaseFeature
 import DomainModule
 import NeedleFoundation
 import PDFKit
-import HPParallaxHeader
 
 public final class ArtistViewController: BaseViewController, ViewControllerFromStoryBoard {
 

--- a/Projects/Features/CommonFeature/Sources/PlayState/PlayState+Playlist.swift
+++ b/Projects/Features/CommonFeature/Sources/PlayState/PlayState+Playlist.swift
@@ -29,7 +29,7 @@ extension PlayState {
         public var list: [PlayListItem] {
             didSet(oldValue) {
                 listChanged.send(list)
-                if oldValue.isEmpty { changeCurrentPlayIndex(to: 0) }
+                if oldValue.isEmpty && !list.isEmpty { changeCurrentPlayIndex(to: 0) }
             }
         }
         public var listChanged: CurrentValueSubject<[PlayListItem], Never>
@@ -77,6 +77,8 @@ extension PlayState {
         
         public func removeAll() {
             list.removeAll()
+            PlayState.shared.stop()
+            PlayState.shared.switchPlayerMode(to: .mini)
         }
         
         public func contains(_ item: PlayListItem) -> Bool {

--- a/Projects/Features/CommonFeature/Sources/PlayState/PlayState+Playlist.swift
+++ b/Projects/Features/CommonFeature/Sources/PlayState/PlayState+Playlist.swift
@@ -8,77 +8,109 @@
 
 import Foundation
 import DomainModule
+import Combine
+
+public struct PlayListItem: Equatable {
+    public var item: SongEntity
+    public var isPlaying: Bool
+    
+    public init(item: SongEntity, isPlaying: Bool = false) {
+        self.item = item
+        self.isPlaying = isPlaying
+    }
+    
+    public static func == (lhs: PlayListItem, rhs: PlayListItem) -> Bool {
+        return lhs.item == rhs.item && lhs.item.isSelected == rhs.item.isSelected && lhs.isPlaying == rhs.isPlaying
+    }
+}
 
 extension PlayState {
     public class PlayList {
-        @Published public var list: [SongEntity]
-        @Published public var currentPlayIndex: Int // 현재 재생중인 노래 인덱스 번호
-        
-        init(list: [SongEntity] = []) {
-            self.list = list
-            currentPlayIndex = 0
+        public var list: [PlayListItem] {
+            didSet(oldValue) {
+                listChanged.send(list)
+                if oldValue.isEmpty { changeCurrentPlayIndex(to: 0) }
+            }
         }
+        public var listChanged: CurrentValueSubject<[PlayListItem], Never>
         
-        public var first: SongEntity? { return list.first }
-        public var last: SongEntity? { return list.last }
-        public var current: SongEntity? { return list[currentPlayIndex] }
+        init(list: [PlayListItem] = []) {
+            self.list = list
+            self.listChanged = .init([])
+        }
+        public var currentPlayIndex: Int? { return list.firstIndex(where: { $0.isPlaying == true }) }
+        public var first: SongEntity? { return list.first?.item }
+        public var last: SongEntity? { return list.last?.item }
         public var count: Int { return list.count }
         public var lastIndex: Int { return list.count - 1 }
         public var isEmpty: Bool { return list.isEmpty }
+        public var isFirst: Bool { return currentPlayIndex == 0 }
         public var isLast: Bool { return currentPlayIndex == lastIndex }
         
-        public func append(_ item: SongEntity) {
+        public func append(_ item: PlayListItem) {
             list.append(item)
         }
         
-        public func insert(_ newElement: SongEntity, at: Int) {
+        public func insert(_ newElement: PlayListItem, at: Int) {
             list.insert(newElement, at: at)
         }
         
-        public func remove(at: Int) {
-            list.remove(at: at)
+        public func remove(at index: Int) {
+            guard let currentPlayIndex = currentPlayIndex else { return }
+            if index == currentPlayIndex {
+                changeCurrentPlayIndexToNext()
+            }
+            
+            list.remove(at: index)
+            
+            if index == currentPlayIndex {
+                PlayState.shared.currentSong = list[currentPlayIndex].item
+                PlayState.shared.loadInPlaylist(at: currentPlayIndex)
+            }
+        }
+        
+        public func remove(indexs: [Int]) {
+            let sortedIndexs = indexs.sorted(by: >) // 앞에서부터 삭제하면 인덱스 순서가 바뀜
+            sortedIndexs.forEach { index in
+                remove(at: index)
+            }
         }
         
         public func removeAll() {
             list.removeAll()
         }
         
-        public func contains(_ item: SongEntity) -> Bool {
+        public func contains(_ item: PlayListItem) -> Bool {
             return list.contains(item)
         }
         
-        public func back() {
-            // 현재 곡이 첫번째 곡이면 마지막 곡으로
-            if currentPlayIndex == 0 { currentPlayIndex = lastIndex; return }
-            currentPlayIndex -= 1
+        public func changeCurrentPlayIndex(to index: Int) {
+            let currentPlayIndex = currentPlayIndex ?? 0
+            list[currentPlayIndex].isPlaying = false
+            list[index].isPlaying = true
         }
         
-        public func next() {
-            // 현재 곡이 마지막이면 첫번째 곡으로
-            if isLast { currentPlayIndex = 0; return }
-            currentPlayIndex += 1
+        public func changeCurrentPlayIndexToPrevious() {
+            guard let currentPlayIndex = currentPlayIndex else { return }
+            let previousIndex = (currentPlayIndex - 1 + list.count) % list.count
+            changeCurrentPlayIndex(to: previousIndex)
+        }
+        
+        public func changeCurrentPlayIndexToNext() {
+            guard let currentPlayIndex = currentPlayIndex else { return }
+            let nextIndex = (currentPlayIndex + 1 + list.count) % list.count
+            changeCurrentPlayIndex(to: nextIndex)
         }
         
         public func reorderPlaylist(from: Int, to: Int) {
             let movedData = list[from]
             list.remove(at: from)
             list.insert(movedData, at: to)
-            
-            if currentPlayIndex == from {
-                currentPlayIndex = to
-            } else if currentPlayIndex > from && currentPlayIndex <= to {
-                currentPlayIndex -= 1
-            } else if currentPlayIndex < from && currentPlayIndex >= to {
-                currentPlayIndex += 1
-            }
         }
         
-        public func uniqueIndex(of item: SongEntity) -> Int? {
+        public func uniqueIndex(of item: PlayListItem) -> Int? {
             // 해당 곡이 이미 재생목록에 있으면 재생목록 속 해당 곡의 index, 없으면 nil 리턴
-            for (index, song) in list.enumerated() {
-                if song == item { return index }
-            }
-            return nil
+            return list.firstIndex(where: { $0.item == item.item })
         }
         
     }

--- a/Projects/Features/CommonFeature/Sources/PlayState/PlayState+Playlist.swift
+++ b/Projects/Features/CommonFeature/Sources/PlayState/PlayState+Playlist.swift
@@ -11,8 +11,8 @@ import DomainModule
 
 extension PlayState {
     public class PlayList {
-        public var list: [SongEntity]
-        public var currentPlayIndex: Int // 현재 재생중인 노래 인덱스 번호
+        @Published public var list: [SongEntity]
+        @Published public var currentPlayIndex: Int // 현재 재생중인 노래 인덱스 번호
         
         init(list: [SongEntity] = []) {
             self.list = list

--- a/Projects/Features/CommonFeature/Sources/PlayState/PlayState+Playlist.swift
+++ b/Projects/Features/CommonFeature/Sources/PlayState/PlayState+Playlist.swift
@@ -63,7 +63,7 @@ extension PlayState {
             list.remove(at: index)
             
             if let currentPlayIndex = currentPlayIndex, index == currentPlayIndex {
-                PlayState.shared.currentSong = list[currentPlayIndex].item
+                PlayState.shared.currentSong = list[safe: currentPlayIndex]?.item
                 PlayState.shared.loadInPlaylist(at: currentPlayIndex)
             }
         }
@@ -107,8 +107,8 @@ extension PlayState {
             list.insert(movedData, at: to)
         }
         
+        /// 해당 곡이 이미 재생목록에 있으면 재생목록 속 해당 곡의 index, 없으면 nil 리턴
         public func uniqueIndex(of item: PlayListItem) -> Int? {
-            // 해당 곡이 이미 재생목록에 있으면 재생목록 속 해당 곡의 index, 없으면 nil 리턴
             return list.firstIndex(where: { $0.item == item.item })
         }
         

--- a/Projects/Features/CommonFeature/Sources/PlayState/PlayState+Playlist.swift
+++ b/Projects/Features/CommonFeature/Sources/PlayState/PlayState+Playlist.swift
@@ -56,14 +56,13 @@ extension PlayState {
         }
         
         public func remove(at index: Int) {
-            guard let currentPlayIndex = currentPlayIndex else { return }
-            if index == currentPlayIndex {
+            if let currentPlayIndex = currentPlayIndex, index == currentPlayIndex {
                 changeCurrentPlayIndexToNext()
             }
             
             list.remove(at: index)
             
-            if index == currentPlayIndex {
+            if let currentPlayIndex = currentPlayIndex, index == currentPlayIndex {
                 PlayState.shared.currentSong = list[currentPlayIndex].item
                 PlayState.shared.loadInPlaylist(at: currentPlayIndex)
             }

--- a/Projects/Features/CommonFeature/Sources/PlayState/PlayState+Public.swift
+++ b/Projects/Features/CommonFeature/Sources/PlayState/PlayState+Public.swift
@@ -16,11 +16,11 @@ public extension PlayState {
     func loadAndAppendSongsToPlaylist(_ songs: [SongEntity], duplicateAllowed: Bool = false) {
         guard let firstSong = songs.first else { return }
         
-        if let uniqueIndex = self.playList.uniqueIndex(of: firstSong) {
-            self.playList.currentPlayIndex = uniqueIndex
+        if let uniqueIndex = self.playList.uniqueIndex(of: PlayListItem(item: firstSong)) {
+            self.playList.changeCurrentPlayIndex(to: uniqueIndex)
         } else {
-            self.playList.append(firstSong)
-            self.playList.currentPlayIndex = self.playList.lastIndex
+            self.playList.append(PlayListItem(item: firstSong))
+            self.playList.changeCurrentPlayIndex(to: self.playList.lastIndex)
         }
         if self.state == .cued {
             self.switchPlayerMode(to: .mini)
@@ -28,8 +28,8 @@ public extension PlayState {
         self.load(at: firstSong)
         
         songs.dropFirst().forEach { song in
-            if self.playList.uniqueIndex(of: song) == nil {
-                self.playList.append(song)
+            if self.playList.uniqueIndex(of: PlayListItem(item: song)) == nil {
+                self.playList.append(PlayListItem(item: song))
             }
         }
     }
@@ -38,8 +38,8 @@ public extension PlayState {
     /// - Parameter duplicateAllowed: 재생목록 추가 시 중복 허용 여부 (기본값: false)
     func appendSongsToPlaylist(_ songs: [SongEntity], duplicateAllowed: Bool = false) {
         songs.forEach { song in
-            if self.playList.uniqueIndex(of: song) == nil {
-                self.playList.append(song)
+            if self.playList.uniqueIndex(of: PlayListItem(item: song)) == nil {
+                self.playList.append(PlayListItem(item: song))
             }
         }
         if self.state == .cued {

--- a/Projects/Features/CommonFeature/Sources/PlayState/PlayState+Public.swift
+++ b/Projects/Features/CommonFeature/Sources/PlayState/PlayState+Public.swift
@@ -15,22 +15,21 @@ public extension PlayState {
     /// - Parameter duplicateAllowed: 재생목록 추가 시 중복 허용 여부 (기본값: false)
     func loadAndAppendSongsToPlaylist(_ songs: [SongEntity], duplicateAllowed: Bool = false) {
         guard let firstSong = songs.first else { return }
+        let uniqueIndex = self.playList.uniqueIndex(of: PlayListItem(item: firstSong))
         
-        if let uniqueIndex = self.playList.uniqueIndex(of: PlayListItem(item: firstSong)) {
+        if let uniqueIndex {
             self.playList.changeCurrentPlayIndex(to: uniqueIndex)
         } else {
             self.playList.append(PlayListItem(item: firstSong))
             self.playList.changeCurrentPlayIndex(to: self.playList.lastIndex)
         }
-        if self.state == .cued {
-            self.switchPlayerMode(to: .mini)
-        }
+        
+        if self.state == .cued { self.switchPlayerMode(to: .mini) }
         self.load(at: firstSong)
         
         songs.dropFirst().forEach { song in
-            if self.playList.uniqueIndex(of: PlayListItem(item: song)) == nil {
-                self.playList.append(PlayListItem(item: song))
-            }
+            let uniqueIndex = self.playList.uniqueIndex(of: PlayListItem(item: song))
+            if uniqueIndex == nil { self.playList.append(PlayListItem(item: song)) }
         }
     }
     
@@ -42,11 +41,7 @@ public extension PlayState {
                 self.playList.append(PlayListItem(item: song))
             }
         }
-        if self.state == .cued {
-            self.switchPlayerMode(to: .mini)
-            guard let song = songs.first else { return }
-            self.player.cue(source: .video(id: song.id))
-            self.currentSong = song
-        }
+        // player.stop 하면 .cued 상태
+        if self.state == .cued { self.switchPlayerMode(to: .mini) }
     }
 }

--- a/Projects/Features/CommonFeature/Sources/PlayState/PlayState+YoutubePlayer.swift
+++ b/Projects/Features/CommonFeature/Sources/PlayState/PlayState+YoutubePlayer.swift
@@ -39,8 +39,8 @@ extension PlayState {
     
     /// ▶️ 플레이리스트의 해당 위치의  곡 재생
     public func loadInPlaylist(at index: Int) {
-        guard (0..<playList.count).contains(index) else { return }
-        self.currentSong = playList.list[index].item
+        guard let playListItem = playList.list[safe: index] else { return }
+        self.currentSong = playListItem.item
         guard let currentSong = currentSong else { return }
         load(at: currentSong)
     }
@@ -49,7 +49,8 @@ extension PlayState {
     public func forward() {
         self.playList.changeCurrentPlayIndexToNext()
         guard let currentPlayIndex = playList.currentPlayIndex else { return }
-        self.currentSong = playList.list[currentPlayIndex].item
+        guard let playListItem = playList.list[safe: currentPlayIndex] else { return }
+        self.currentSong = playListItem.item
         guard let currentSong = currentSong else { return }
         load(at: currentSong)
     }
@@ -58,7 +59,8 @@ extension PlayState {
     public func backward() {
         self.playList.changeCurrentPlayIndexToPrevious()
         guard let currentPlayIndex = playList.currentPlayIndex else { return }
-        self.currentSong = playList.list[currentPlayIndex].item
+        guard let playListItem = playList.list[safe: currentPlayIndex] else { return }
+        self.currentSong = playListItem.item
         guard let currentSong = currentSong else { return }
         load(at: currentSong)
     }

--- a/Projects/Features/CommonFeature/Sources/PlayState/PlayState+YoutubePlayer.swift
+++ b/Projects/Features/CommonFeature/Sources/PlayState/PlayState+YoutubePlayer.swift
@@ -27,7 +27,7 @@ extension PlayState {
         self.player.stop()
         self.currentSong = nil
         self.progress.clear()
-        self.playList.list.removeAll()
+        //self.playList.removeAll()
     }
     
     /// ▶️ 해당 곡 새로 재생

--- a/Projects/Features/CommonFeature/Sources/PlayState/PlayState+YoutubePlayer.swift
+++ b/Projects/Features/CommonFeature/Sources/PlayState/PlayState+YoutubePlayer.swift
@@ -39,24 +39,26 @@ extension PlayState {
     
     /// ▶️ 플레이리스트의 해당 위치의  곡 재생
     public func loadInPlaylist(at index: Int) {
-        self.playList.currentPlayIndex = index
-        self.currentSong = self.playList.current
+        guard (0..<playList.count).contains(index) else { return }
+        self.currentSong = playList.list[index].item
         guard let currentSong = currentSong else { return }
         load(at: currentSong)
     }
     
     /// ⏩ 다음 곡으로 변경 후 재생
     public func forward() {
-        self.playList.next()
-        self.currentSong = playList.current
+        self.playList.changeCurrentPlayIndexToNext()
+        guard let currentPlayIndex = playList.currentPlayIndex else { return }
+        self.currentSong = playList.list[currentPlayIndex].item
         guard let currentSong = currentSong else { return }
         load(at: currentSong)
     }
     
     /// ⏪ 이전 곡으로 변경 후 재생
     public func backward() {
-        self.playList.back()
-        self.currentSong = playList.current
+        self.playList.changeCurrentPlayIndexToPrevious()
+        guard let currentPlayIndex = playList.currentPlayIndex else { return }
+        self.currentSong = playList.list[currentPlayIndex].item
         guard let currentSong = currentSong else { return }
         load(at: currentSong)
     }
@@ -73,7 +75,7 @@ extension PlayState {
     
     /// ♻️ 첫번째 곡으로 변경 후 재생
     public func playAgain() {
-        self.playList.currentPlayIndex = 0
+        self.playList.changeCurrentPlayIndex(to: 0)
         self.currentSong = playList.first
         guard let currentSong = currentSong else { return }
         load(at: currentSong)

--- a/Projects/Features/CommonFeature/Sources/PlayState/PlayState.swift
+++ b/Projects/Features/CommonFeature/Sources/PlayState/PlayState.swift
@@ -60,6 +60,12 @@ final public class PlayState {
             self.progress.endProgress = duration
         }.store(in: &subscription)
         
+        playList.$list.sink { [weak self] list in
+            guard let self else { return }
+            guard let source = self.player.source?.id else { return }
+            guard let index = list.firstIndex(where: { $0.id == source }) else { return }
+            self.playList.currentPlayIndex = index
+        }.store(in: &subscription)
         
     }
     

--- a/Projects/Features/CommonFeature/Sources/PlayState/PlayState.swift
+++ b/Projects/Features/CommonFeature/Sources/PlayState/PlayState.swift
@@ -24,27 +24,14 @@ final public class PlayState {
     
     private var subscription = Set<AnyCancellable>()
     
-    private let dummyPlayList = [
-        SongEntity(id: "fgSXAKsq-Vo", title: "리와인드 (RE:WIND)", artist: "이세계아이돌", remix: "", reaction: "", views: 13442558, last: 0, date: "211222"),
-        SongEntity(id: "wSG93VZoMFg", title: "[메타시그널 OST] In Romantic", artist: "해루석", remix: "", reaction: "", views: 320864, last: 0, date: "221216"),
-        SongEntity(id: "kHpvUymXXEg", title: "KICK BACK #Shrots", artist: "왁컬로이두", remix: "", reaction: "", views: 887629, last: 0, date: "220216"),
-        SongEntity(id: "rhOF0nwhEmU", title: "ANTIFRAGILE Challenge Vtuber Cover #Shorts", artist: "징버거", remix: "", reaction: "", views: 423708, last: 0, date: "221209"),
-        SongEntity(id: "N2Tj_FMqlX8", title: "왁타버스 디즈니 메들리", artist: "비챤 X 고정멤버", remix: "", reaction: "", views: 864251, last: 0, date: "220722"),
-        SongEntity(id: "tT-kuonVzfY", title: "STAY", artist: "징버거", remix: "", reaction: "", views: 1487185, last: 0, date: "230120"),
-        SongEntity(id: "l8e1Byk1Dx0", title: "TRUE LOVER (트루러버)", artist: "해루석, 히키킹, 권민(ft.행주)", remix: "", reaction: "", views: 7075068, last: 0, date: "220918")
-    ]
-    
     init() {
-        //playList = PlayList()
-        playList = PlayList(list: dummyPlayList)
-        currentSong = SongEntity(id: "fgSXAKsq-Vo", title: "리와인드 (RE:WIND)", artist: "이세계아이돌", remix: "", reaction: "", views: 13442558, last: 0, date: "211222")
+        playList = PlayList()
         progress = PlayProgress()
         state = .unstarted
         repeatMode = .none
         shuffleMode = .off
-        
-        player = YouTubePlayer(source: .video(id: "fgSXAKsq-Vo"), configuration: .init(autoPlay: false, showControls: false, showRelatedVideos: false))
-        
+        player = YouTubePlayer(configuration: .init(autoPlay: false, showControls: false, showRelatedVideos: false))
+                
         player.playbackStatePublisher.sink { [weak self] state in
             guard let self = self else { return }
             self.state = state
@@ -58,13 +45,6 @@ final public class PlayState {
         player.durationPublisher.sink { [weak self] duration in
             guard let self = self else { return }
             self.progress.endProgress = duration
-        }.store(in: &subscription)
-        
-        playList.$list.sink { [weak self] list in
-            guard let self else { return }
-            guard let source = self.player.source?.id else { return }
-            guard let index = list.firstIndex(where: { $0.id == source }) else { return }
-            self.playList.currentPlayIndex = index
         }.store(in: &subscription)
         
     }

--- a/Projects/Features/CommonFeature/Sources/ViewControllers/PlayListDetailViewController.swift
+++ b/Projects/Features/CommonFeature/Sources/ViewControllers/PlayListDetailViewController.swift
@@ -357,11 +357,6 @@ extension PlayListDetailViewController{
                 }
             })
             .disposed(by: disposeBag)
-        
-        output.songEntityOfSelectedSongs
-            .filter{ !$0.isEmpty }
-            .subscribe()
-            .disposed(by: disposeBag)
     }
 }
 

--- a/Projects/Features/CommonFeature/Tests/TargetTests.swift
+++ b/Projects/Features/CommonFeature/Tests/TargetTests.swift
@@ -1,7 +1,13 @@
 import XCTest
+import CommonFeature
+import DomainModule
+import Combine
 
 class TargetTests: XCTestCase {
-
+    var playState = PlayState.shared
+    var playlist = PlayState.shared.playList
+    var subscription = Set<AnyCancellable>()
+    
     override func setUpWithError() throws {
         // Put setup code here. This method is called before the invocation of each test method in the class.
     }
@@ -12,6 +18,75 @@ class TargetTests: XCTestCase {
 
     func testExample() throws {
         XCTAssertEqual("A", "A")
+    }
+    
+    func testRemoveSong() {
+        // given
+        let list = [
+            SongEntity(id: "", title: "제목1", artist: "", remix: "", reaction: "", views: 0, last: 0, date: ""),
+            SongEntity(id: "", title: "제목2", artist: "", remix: "", reaction: "", views: 0, last: 0, date: ""),
+            SongEntity(id: "", title: "제목3", artist: "", remix: "", reaction: "", views: 0, last: 0, date: ""),
+            SongEntity(id: "", title: "제목4", artist: "", remix: "", reaction: "", views: 0, last: 0, date: ""),
+            SongEntity(id: "", title: "제목5", artist: "", remix: "", reaction: "", views: 0, last: 0, date: ""),
+            SongEntity(id: "", title: "제목6", artist: "", remix: "", reaction: "", views: 0, last: 0, date: ""),
+            SongEntity(id: "", title: "제목7", artist: "", remix: "", reaction: "", views: 0, last: 0, date: "")
+        ].map { PlayListItem(item: $0) }
+        
+        playlist.list = list
+        playlist.changeCurrentPlayIndex(to: 2)
+        
+        // when
+        playlist.remove(indexs: [1, 2, 4, 5])
+        
+        // then
+        var currentPlayIndex = playlist.currentPlayIndex ?? -1
+        XCTAssertEqual(currentPlayIndex , 1)
+        XCTAssertEqual(playlist.count, 3)
+        XCTAssertEqual(playlist.list[0].item.title, "제목1")
+        XCTAssertEqual(playlist.list[1].item.title, "제목4")
+        
+        // given
+        playlist.list = list
+        playlist.changeCurrentPlayIndex(to: playlist.lastIndex)
+        
+        // when
+        playlist.remove(indexs: [4, 5, 6])
+        
+        // then
+        currentPlayIndex = playlist.currentPlayIndex ?? -1
+        XCTAssertEqual(currentPlayIndex , 0)
+        XCTAssertEqual(playlist.count, 4)
+        XCTAssertEqual(playlist.list[0].item.title, "제목1")
+        XCTAssertEqual(playlist.list[1].item.title, "제목2")
+    }
+    
+    func testRorderSong() {
+        // given
+        let list = [
+            SongEntity(id: "", title: "제목1", artist: "", remix: "", reaction: "", views: 0, last: 0, date: ""),
+            SongEntity(id: "", title: "제목2", artist: "", remix: "", reaction: "", views: 0, last: 0, date: ""),
+            SongEntity(id: "", title: "제목3", artist: "", remix: "", reaction: "", views: 0, last: 0, date: ""),
+            SongEntity(id: "", title: "제목4", artist: "", remix: "", reaction: "", views: 0, last: 0, date: ""),
+            SongEntity(id: "", title: "제목5", artist: "", remix: "", reaction: "", views: 0, last: 0, date: ""),
+            SongEntity(id: "", title: "제목6", artist: "", remix: "", reaction: "", views: 0, last: 0, date: ""),
+            SongEntity(id: "", title: "제목7", artist: "", remix: "", reaction: "", views: 0, last: 0, date: "")
+        ].map { PlayListItem(item: $0) }
+        playlist.list = list
+        
+        // when
+        playlist.reorderPlaylist(from: 2, to: 1)
+        
+        // then
+        var currentPlayIndex = playlist.currentPlayIndex ?? -1
+        XCTAssertEqual(currentPlayIndex, 0)
+        
+        // when
+        playlist.reorderPlaylist(from: 0, to: 6)
+        
+        // then
+        currentPlayIndex = playlist.currentPlayIndex ?? -1
+        XCTAssertEqual(currentPlayIndex, 6)
+        
     }
 
 }

--- a/Projects/Features/PlayerFeature/Sources/ViewControllers/PlaylistViewController+Delegate.swift
+++ b/Projects/Features/PlayerFeature/Sources/ViewControllers/PlaylistViewController+Delegate.swift
@@ -1,0 +1,83 @@
+//
+//  PlaylistViewController+SongCartViewDelegate.swift
+//  PlayerFeature
+//
+//  Created by YoungK on 2023/04/07.
+//  Copyright © 2023 yongbeomkwak. All rights reserved.
+//
+
+import UIKit
+import CommonFeature
+import DomainModule
+import DesignSystem
+import Utility
+
+extension PlaylistViewController: SongCartViewDelegate {
+    public func buttonTapped(type: SongCartSelectType) {
+        switch type {
+        case let .allSelect(flag):
+            self.isSelectedAllSongs.onNext(flag)
+        case .addPlayList:
+            self.tappedAddPlaylist.onNext(())
+            self.hideSongCart()
+        case .remove:
+            let count: Int = self.viewModel.countOfSelectedSongs
+            let popup = TextPopupViewController.viewController(
+                text: "선택한 내 리스트 \(count)개가 삭제됩니다.",
+                cancelButtonIsHidden: false,
+                completion: { [weak self] () in
+                    guard let self else { return }
+                    self.tappedRemoveSongs.onNext(())
+                    self.hideSongCart()
+                })
+            self.showPanModal(content: popup)
+        default:
+            return
+        }
+    }
+}
+
+extension PlaylistViewController: UITableViewDelegate {
+
+    public func tableView(_ tableView: UITableView, editingStyleForRowAt indexPath: IndexPath) -> UITableViewCell.EditingStyle {
+        return .none // 편집모드 시 왼쪽 버튼을 숨기려면 .none을 리턴합니다.
+    }
+    
+    public func tableView(_ tableView: UITableView, shouldIndentWhileEditingRowAt indexPath: IndexPath) -> Bool {
+        return false // 편집모드 시 셀의 들여쓰기를 없애려면 false를 리턴합니다.
+    }
+    
+    public func tableView(_ tableView: UITableView, dragIndicatorViewForRowAt indexPath: IndexPath) -> UIView? {
+        // 편집모드 시 나타나는 오른쪽 Drag Indicator를 변경합니다.
+        let dragIndicatorView = UIImageView(image: DesignSystemAsset.Player.playLarge.image)
+        dragIndicatorView.frame = .init(x: 0, y: 0, width: 32, height: 32)
+        return dragIndicatorView
+    }
+    
+    public func tableView(_ tableView: UITableView, canMoveRowAt indexPath: IndexPath) -> Bool {
+        return true // 모든 Cell 을 이동 가능하게 설정합니다.
+    }
+    
+    public func tableView(_ tableView: UITableView, moveRowAt sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath) {
+        // 이동할 데이터를 가져와서 새로운 위치에 삽입합니다.
+        playState.playList.reorderPlaylist(from: sourceIndexPath.row, to: destinationIndexPath.row)
+        HapticManager.shared.impact(style: .light)
+    }
+    
+    public func tableView(_ tableView: UITableView, targetIndexPathForMoveFromRowAt sourceIndexPath: IndexPath, toProposedIndexPath proposedDestinationIndexPath: IndexPath) -> IndexPath {
+        // 첫 번째 섹션에서만 이동 가능하게 설정합니다.
+        if proposedDestinationIndexPath.section != 0 {
+            return sourceIndexPath
+        }
+        return proposedDestinationIndexPath
+    }
+    
+}
+
+extension PlaylistViewController: PlaylistTableViewCellDelegate {
+    func superButtonTapped(index: Int) {
+        tappedCellIndex.onNext(index)
+    }
+    
+    
+}

--- a/Projects/Features/PlayerFeature/Sources/ViewControllers/PlaylistViewController+Delegate.swift
+++ b/Projects/Features/PlayerFeature/Sources/ViewControllers/PlaylistViewController+Delegate.swift
@@ -17,9 +17,15 @@ extension PlaylistViewController: SongCartViewDelegate {
         switch type {
         case let .allSelect(flag):
             self.isSelectedAllSongs.onNext(flag)
-        case .addPlayList:
-            self.tappedAddPlaylist.onNext(())
-            self.hideSongCart()
+        case .addSong:
+            let songs: [String] = self.playState.playList.list.map { $0.item.id }
+            let viewController = containSongsComponent.makeView(songs: songs)
+            viewController.modalPresentationStyle = .overFullScreen
+            self.present(viewController, animated: true) {
+                self.tappedAddPlaylist.onNext(())
+                self.hideSongCart()
+            }
+            
         case .remove:
             let count: Int = self.viewModel.countOfSelectedSongs
             let popup = TextPopupViewController.viewController(

--- a/Projects/Features/PlayerFeature/Sources/ViewControllers/PlaylistViewController.swift
+++ b/Projects/Features/PlayerFeature/Sources/ViewControllers/PlaylistViewController.swift
@@ -146,12 +146,21 @@ private extension PlaylistViewController {
     }
     
     private func bindThumbnail(output: PlaylistViewModel.Output) {
-        output.thumbnailImageURL.sink { [weak self] thumbnailImageURL in
+        if let song = playState.player.source {
+            let thumbnailImageURL = Utility.WMImageAPI.fetchYoutubeThumbnail(id: song.id).toString
+            self.playlistView.thumbnailImageView.kf.setImage(
+                with: URL(string: thumbnailImageURL),
+                placeholder: DesignSystemAsset.Logo.placeHolderSmall.image,
+                options: [.transition(.fade(0.2))])
+        }
+        
+        output.thumbnailImageURL
+            .dropFirst()
+            .sink { [weak self] thumbnailImageURL in
             self?.playlistView.thumbnailImageView.kf.setImage(
                 with: URL(string: thumbnailImageURL),
                 placeholder: DesignSystemAsset.Logo.placeHolderSmall.image,
-                options: [.transition(.fade(0.2))]
-            )
+                options: [.transition(.fade(0.2))])
         }.store(in: &subscription)
     }
     

--- a/Projects/Features/PlayerFeature/Sources/ViewControllers/PlaylistViewController.swift
+++ b/Projects/Features/PlayerFeature/Sources/ViewControllers/PlaylistViewController.swift
@@ -63,30 +63,6 @@ public class PlaylistViewController: UIViewController, SongCartViewType {
     }
 }
 
-extension PlaylistViewController {
-    private func createDatasources(output: PlaylistViewModel.Output) -> RxTableViewSectionedReloadDataSource<PlayListSectionModel> {
-        let datasource = RxTableViewSectionedReloadDataSource<PlayListSectionModel>(configureCell: { [weak self] (_ , tableView, indexPath, model) -> UITableViewCell in
-            guard let self else { return UITableViewCell() }
-            guard let cell = tableView.dequeueReusableCell(withIdentifier:  PlaylistTableViewCell.identifier, for: IndexPath(row: indexPath.row, section: 0)) as? PlaylistTableViewCell
-            else { return UITableViewCell() }
-            
-            cell.delegate = self
-            cell.setContent(song: model, output.editState.value, index: indexPath.row)
-            cell.selectionStyle = .none
-            cell.isPlaying = indexPath.row == self.playState.playList.currentPlayIndex
-            cell.isAnimating = self.playState.state == .playing
-            
-            return cell
-            
-        }, canEditRowAtIndexPath: { (_, _) -> Bool in
-            return true
-        }, canMoveRowAtIndexPath: { (_, _) -> Bool in
-            return true
-        })
-        return datasource
-    }
-}
-
 private extension PlaylistViewController {
     private func bindViewModel() {
         let input = PlaylistViewModel.Input(
@@ -240,7 +216,30 @@ private extension PlaylistViewController {
 }
 
 extension PlaylistViewController {
-
+    private func createDatasources(output: PlaylistViewModel.Output) -> RxTableViewSectionedReloadDataSource<PlayListSectionModel> {
+        let datasource = RxTableViewSectionedReloadDataSource<PlayListSectionModel>(configureCell: { [weak self] (_ , tableView, indexPath, model) -> UITableViewCell in
+            guard let self else { return UITableViewCell() }
+            guard let cell = tableView.dequeueReusableCell(withIdentifier:  PlaylistTableViewCell.identifier, for: IndexPath(row: indexPath.row, section: 0)) as? PlaylistTableViewCell
+            else { return UITableViewCell() }
+            
+            cell.delegate = self
+            cell.selectionStyle = .none
+            
+            let index = indexPath.row
+            let isEditing = output.editState.value
+            let isPlaying = indexPath.row == self.playState.playList.currentPlayIndex
+            let isAnimating = self.playState.state == .playing
+            
+            cell.setContent(song: model, index: index, isEditing: isEditing, isPlaying: isPlaying, isAnimating: isAnimating)
+            return cell
+            
+        }, canEditRowAtIndexPath: { (_, _) -> Bool in
+            return true
+        }, canMoveRowAtIndexPath: { (_, _) -> Bool in
+            return true
+        })
+        return datasource
+    }
 }
 
 extension PlaylistViewController: UITableViewDelegate {

--- a/Projects/Features/PlayerFeature/Sources/ViewControllers/PlaylistViewController.swift
+++ b/Projects/Features/PlayerFeature/Sources/ViewControllers/PlaylistViewController.swift
@@ -245,27 +245,7 @@ extension PlaylistViewController {
 }
 
 extension PlaylistViewController: UITableViewDelegate {
-//    public func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-//        return playState.playList.count
-//    }
-//
-//    public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-//        guard let cell = tableView.dequeueReusableCell(withIdentifier: PlaylistTableViewCell.identifier, for: indexPath) as? PlaylistTableViewCell
-//        else { return UITableViewCell() }
-//        cell.selectionStyle = .none
-//        let songs = playState.playList.list
-//        cell.setContent(song: songs[indexPath.row])
-//        cell.isPlaying = indexPath.row == playState.playList.currentPlayIndex
-//        cell.isAnimating = playState.state == .playing
-//        return cell
-//    }
-//
-//    public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-//        if playState.playList.currentPlayIndex != indexPath.row {
-//            playState.loadInPlaylist(at: indexPath.row) // 현재 재생중인 곡 이외의 Cell을 선택 시 해당 곡이 재생됩니다.
-//        }
-//    }
-    
+
     public func tableView(_ tableView: UITableView, editingStyleForRowAt indexPath: IndexPath) -> UITableViewCell.EditingStyle {
         return .none // 편집모드 시 왼쪽 버튼을 숨기려면 .none을 리턴합니다.
     }
@@ -301,9 +281,9 @@ extension PlaylistViewController: UITableViewDelegate {
     
 }
 
-extension PlaylistViewController: PlayListCellDelegate {
-    func buttonTapped(index: Int) {
-        print(index)
+extension PlaylistViewController: PlaylistTableViewCellDelegate {
+    func superButtonTapped(index: Int) {
+        
     }
     
     

--- a/Projects/Features/PlayerFeature/Sources/ViewControllers/PlaylistViewController.swift
+++ b/Projects/Features/PlayerFeature/Sources/ViewControllers/PlaylistViewController.swift
@@ -31,7 +31,7 @@ public class PlaylistViewController: UIViewController, SongCartViewType {
     var tappedAddPlaylist = PublishSubject<Void>()
     var tappedRemoveSongs = PublishSubject<Void>()
     
-    private var containSongsComponent: ContainSongsComponent!
+    internal var containSongsComponent: ContainSongsComponent!
     
     public var songCartView: CommonFeature.SongCartView!
     public var bottomSheetView: CommonFeature.BottomSheetView!

--- a/Projects/Features/PlayerFeature/Sources/ViewControllers/PlaylistViewController.swift
+++ b/Projects/Features/PlayerFeature/Sources/ViewControllers/PlaylistViewController.swift
@@ -99,7 +99,8 @@ private extension PlaylistViewController {
             shuffleButtonDidTapEvent: playlistView.shuffleButton.tapPublisher,
             playlistTableviewCellDidTapEvent: tappedCellIndex.asObservable(),
             selectAllSongsButtonDidTapEvent: isSelectedAllSongs.asObservable(),
-            removeSongsButtonDidTapEvent: tappedRemoveSongs.asObservable()
+            removeSongsButtonDidTapEvent: tappedRemoveSongs.asObservable(),
+            itemMovedEvent: playlistView.playlistTableView.rx.itemMoved.asObservable()
         )
         let output = self.viewModel.transform(from: input)
         

--- a/Projects/Features/PlayerFeature/Sources/ViewControllers/PlaylistViewController.swift
+++ b/Projects/Features/PlayerFeature/Sources/ViewControllers/PlaylistViewController.swift
@@ -166,8 +166,8 @@ private extension PlaylistViewController {
                 guard let cell = self.playlistView.playlistTableView.cellForRow(at: IndexPath(row: index, section: 0)) as? PlaylistTableViewCell else { return nil }
                 return (cell, state == .playing)
             }
-            .sink { cell, isPlaying in
-                if isPlaying {
+            .sink { cell, isAnimating in
+                if isAnimating {
                     cell.waveStreamAnimationView.play()
                 } else {
                     cell.waveStreamAnimationView.pause()
@@ -199,6 +199,7 @@ extension PlaylistViewController: UITableViewDelegate, UITableViewDataSource {
         let songs = playState.playList.list
         cell.setContent(song: songs[indexPath.row])
         cell.isPlaying = indexPath.row == playState.playList.currentPlayIndex
+        cell.isAnimating = playState.state == .playing
         return cell
     }
     

--- a/Projects/Features/PlayerFeature/Sources/ViewControllers/PlaylistViewController.swift
+++ b/Projects/Features/PlayerFeature/Sources/ViewControllers/PlaylistViewController.swift
@@ -27,6 +27,8 @@ public class PlaylistViewController: UIViewController, SongCartViewType {
     var disposeBag = DisposeBag()
     
     var tappedCellIndex = PublishSubject<Int>()
+    var isSelectedAllSongs = PublishSubject<Bool>()
+    var tappedRemoveSongs = PublishSubject<Void>()
     
     private var containSongsComponent: ContainSongsComponent!
     
@@ -95,7 +97,9 @@ private extension PlaylistViewController {
             playButtonDidTapEvent: playlistView.playButton.tapPublisher,
             nextButtonDidTapEvent: playlistView.nextButton.tapPublisher,
             shuffleButtonDidTapEvent: playlistView.shuffleButton.tapPublisher,
-            playlistTableviewCellDidTapEvent: tappedCellIndex.asObservable()
+            playlistTableviewCellDidTapEvent: tappedCellIndex.asObservable(),
+            selectAllSongsButtonDidTapEvent: isSelectedAllSongs.asObservable(),
+            removeSongsButtonDidTapEvent: tappedRemoveSongs.asObservable()
         )
         let output = self.viewModel.transform(from: input)
         

--- a/Projects/Features/PlayerFeature/Sources/ViewModels/PlayerViewModel+API.swift
+++ b/Projects/Features/PlayerFeature/Sources/ViewModels/PlayerViewModel+API.swift
@@ -78,6 +78,7 @@ extension PlayerViewModel {
                 if status == 200 {
                     output.likeState.send(false)
                     output.likeCountText.send(likeCountText)
+                    NotificationCenter.default.post(name: .likeListRefresh, object: nil)
                 } else {
                     output.showToastMessage.send(description)
                 }
@@ -105,6 +106,7 @@ extension PlayerViewModel {
                 if status == 200 {
                     output.likeState.send(true)
                     output.likeCountText.send(likeCountText)
+                    NotificationCenter.default.post(name: .likeListRefresh, object: nil)
                 } else {
                     output.showToastMessage.send(description)
                 }

--- a/Projects/Features/PlayerFeature/Sources/ViewModels/PlayerViewModel.swift
+++ b/Projects/Features/PlayerFeature/Sources/ViewModels/PlayerViewModel.swift
@@ -154,6 +154,7 @@ final class PlayerViewModel: ViewModelType {
         }.disposed(by: disposeBag)
         
         input.likeButtonDidTapEvent
+            .throttle(for: .seconds(1), scheduler: DispatchQueue.main, latest: true)
             .map {
                 Utility.PreferenceManager.userInfo != nil
             }

--- a/Projects/Features/PlayerFeature/Sources/ViewModels/PlaylistViewModel.swift
+++ b/Projects/Features/PlayerFeature/Sources/ViewModels/PlaylistViewModel.swift
@@ -266,6 +266,7 @@ final class PlaylistViewModel: ViewModelType {
                 guard let self else { return }
                 let localPlaylist = output.dataSource.value.first?.items ?? []
                 self.playState.playList.list = localPlaylist
+                output.indexOfSelectedSongs.accept([])
         }.store(in: &subscription)
     }
     

--- a/Projects/Features/PlayerFeature/Sources/ViewModels/PlaylistViewModel.swift
+++ b/Projects/Features/PlayerFeature/Sources/ViewModels/PlaylistViewModel.swift
@@ -143,6 +143,22 @@ final class PlaylistViewModel: ViewModelType {
             }
             .bind(to: output.indexOfSelectedSongs)
             .disposed(by: disposeBag)
+        
+        input.removeSongsButtonDidTapEvent
+            .withLatestFrom(output.songEntityOfSelectedSongs){ $1 }
+            .withLatestFrom(output.dataSource) { ($0,$1)}
+            .map({ (ids:[SongEntity],dataSource:[PlayListDetailSectionModel])  -> [PlayListDetailSectionModel] in
+                let remainDataSource = dataSource.first?.items.filter({ (song:SongEntity) in
+                    return !ids.contains(song)
+                })
+                
+                output.songEntityOfSelectedSongs.accept([])
+                output.indexOfSelectedSongs.accept([])
+                
+                return [PlayListDetailSectionModel(model: 0, items: remainDataSource ?? [])]
+            })
+            .bind(to: output.dataSource)
+            .disposed(by: disposeBag)
     }
     
     private func bindTableView(output: Output) {

--- a/Projects/Features/PlayerFeature/Sources/ViewModels/PlaylistViewModel.swift
+++ b/Projects/Features/PlayerFeature/Sources/ViewModels/PlaylistViewModel.swift
@@ -164,6 +164,27 @@ final class PlaylistViewModel: ViewModelType {
             }
             .bind(to: output.dataSource)
             .disposed(by: disposeBag)
+        
+        output.indexOfSelectedSongs
+            .withLatestFrom(output.dataSource) { ($0, $1) }
+            .map { (indexOfSelectedSongs, dataSource) in
+                let playlist = dataSource.first?.items ?? []
+                
+                return indexOfSelectedSongs.map {
+                        SongEntity(
+                        id: playlist[$0].id,
+                        title: playlist[$0].title,
+                        artist: playlist[$0].artist,
+                        remix: playlist[$0].remix,
+                        reaction: playlist[$0].reaction,
+                        views: playlist[$0].views,
+                        last: playlist[$0].last,
+                        date: playlist[$0].date
+                    )
+                }
+            }
+            .bind(to: output.songEntityOfSelectedSongs)
+            .disposed(by: disposeBag)
 
     }
     

--- a/Projects/Features/PlayerFeature/Sources/ViewModels/PlaylistViewModel.swift
+++ b/Projects/Features/PlayerFeature/Sources/ViewModels/PlaylistViewModel.swift
@@ -28,6 +28,7 @@ final class PlaylistViewModel: ViewModelType {
         let playButtonDidTapEvent: AnyPublisher<Void, Never>
         let nextButtonDidTapEvent: AnyPublisher<Void, Never>
         let shuffleButtonDidTapEvent: AnyPublisher<Void, Never>
+        let songTapped: PublishSubject<Int> = PublishSubject()
         let allSongSelected: PublishSubject<Bool> = PublishSubject()
         let tapRemoveSongs: PublishSubject<Void> = PublishSubject()
         
@@ -35,7 +36,7 @@ final class PlaylistViewModel: ViewModelType {
     struct Output {
         var playerState = CurrentValueSubject<YouTubePlayer.PlaybackState, Never>(.unstarted)
         var willClosePlaylist = PassthroughSubject<Bool, Never>()
-        var editState = PassthroughSubject<Bool, Never>()
+        var editState = CurrentValueSubject<Bool, Never>(false)
         var thumbnailImageURL = CurrentValueSubject<String, Never>("")
         var playTimeValue = CurrentValueSubject<Float, Never>(0.0)
         var totalTimeValue = CurrentValueSubject<Float, Never>(0.0)

--- a/Projects/Features/PlayerFeature/Sources/ViewModels/PlaylistViewModel.swift
+++ b/Projects/Features/PlayerFeature/Sources/ViewModels/PlaylistViewModel.swift
@@ -29,8 +29,8 @@ final class PlaylistViewModel: ViewModelType {
         let nextButtonDidTapEvent: AnyPublisher<Void, Never>
         let shuffleButtonDidTapEvent: AnyPublisher<Void, Never>
         let playlistTableviewCellDidTapEvent: Observable<Int>
-        let allSongSelected: PublishSubject<Bool> = PublishSubject()
-        let tapRemoveSongs: PublishSubject<Void> = PublishSubject()
+        let selectAllSongsButtonDidTapEvent: Observable<Bool>
+        let removeSongsButtonDidTapEvent: Observable<Void>
         
     }
     struct Output {

--- a/Projects/Features/PlayerFeature/Sources/ViewModels/PlaylistViewModel.swift
+++ b/Projects/Features/PlayerFeature/Sources/ViewModels/PlaylistViewModel.swift
@@ -163,6 +163,8 @@ final class PlaylistViewModel: ViewModelType {
         
         input.addPlaylistButtonDidTapEvent
             .subscribe { _ in
+                output.indexOfSelectedSongs.accept([])
+                output.editState.send(false)
             }.disposed(by: disposeBag)
         
         input.removeSongsButtonDidTapEvent

--- a/Projects/Features/PlayerFeature/Sources/ViewModels/PlaylistViewModel.swift
+++ b/Projects/Features/PlayerFeature/Sources/ViewModels/PlaylistViewModel.swift
@@ -8,10 +8,16 @@
 
 import Foundation
 import Combine
+import RxSwift
+import RxRelay
+import RxDataSources
 import BaseFeature
 import YouTubePlayerKit
 import Utility
 import CommonFeature
+import DomainModule
+
+internal typealias PlayListSectionModel = SectionModel<Int, SongEntity>
 
 final class PlaylistViewModel: ViewModelType {
     struct Input {
@@ -22,6 +28,8 @@ final class PlaylistViewModel: ViewModelType {
         let playButtonDidTapEvent: AnyPublisher<Void, Never>
         let nextButtonDidTapEvent: AnyPublisher<Void, Never>
         let shuffleButtonDidTapEvent: AnyPublisher<Void, Never>
+        let allSongSelected: PublishSubject<Bool> = PublishSubject()
+        let tapRemoveSongs: PublishSubject<Void> = PublishSubject()
         
     }
     struct Output {
@@ -34,6 +42,9 @@ final class PlaylistViewModel: ViewModelType {
         var currentSongIndex = CurrentValueSubject<Int, Never>(0)
         var repeatMode = CurrentValueSubject<RepeatMode, Never>(.none)
         var shuffleMode = CurrentValueSubject<ShuffleMode, Never>(.off)
+        let dataSource: BehaviorRelay<[PlayListSectionModel]> = BehaviorRelay(value: [])
+        let indexOfSelectedSongs: BehaviorRelay<[Int]> = BehaviorRelay(value: [])
+        let songEntityOfSelectedSongs: BehaviorRelay<[SongEntity]> = BehaviorRelay(value: [])
     }
     
     private let playState = PlayState.shared
@@ -50,6 +61,9 @@ final class PlaylistViewModel: ViewModelType {
     
     func transform(from input: Input) -> Output {
         let output = Output()
+        
+        output.dataSource.accept([PlayListSectionModel(model: 0, items: playState.playList.list)])
+        // 테이블뷰 -> 뷰모델 dataSource  < --- 동기화 --- > PlayState.playlist.list
         
         bindInput(input: input, output: output)
         bindPlayStateChanged(output: output)

--- a/Projects/Features/PlayerFeature/Sources/Views/PlaylistTableViewCell.swift
+++ b/Projects/Features/PlayerFeature/Sources/Views/PlaylistTableViewCell.swift
@@ -74,11 +74,7 @@ internal class PlaylistTableViewCell: UITableViewCell {
     
     internal var isPlaying: Bool = false
     
-    internal var isAnimating: Bool = false {
-        didSet {
-            isAnimating ? waveStreamAnimationView.play() : waveStreamAnimationView.pause()
-        }
-    }
+    internal var isAnimating: Bool = false
     
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -146,7 +142,6 @@ internal class PlaylistTableViewCell: UITableViewCell {
 
 extension PlaylistTableViewCell {
     internal func setContent(song: SongEntity, index: Int, isEditing: Bool, isPlaying: Bool, isAnimating: Bool) {
-        print("셋컨텐트 호출됨", song.title)
         self.thumbnailImageView.kf.setImage(
             with: URL(string: Utility.WMImageAPI.fetchYoutubeThumbnail(id: song.id).toString),
             placeholder: DesignSystemAsset.Logo.placeHolderSmall.image,
@@ -161,6 +156,7 @@ extension PlaylistTableViewCell {
         self.updateButtonHidden(isEditing: isEditing, isPlaying: isPlaying)
         self.updateConstraintPlayImageView(isEditing: isEditing)
         self.updateLabelHighlight(isPlaying: isPlaying)
+        self.updateAnimating(isAnimating: isAnimating)
     }
     
     @objc func superButtonSelectedAction() {
@@ -188,6 +184,10 @@ extension PlaylistTableViewCell {
     private func updateLabelHighlight(isPlaying: Bool) {
         titleLabel.textColor = isPlaying ? DesignSystemAsset.PrimaryColor.point.color : DesignSystemAsset.GrayColor.gray900.color
         artistLabel.textColor = isPlaying ? DesignSystemAsset.PrimaryColor.point.color : DesignSystemAsset.GrayColor.gray900.color
+    }
+    
+    private func updateAnimating(isAnimating: Bool) {
+        isAnimating ? self.waveStreamAnimationView.play() : self.waveStreamAnimationView.pause()
     }
     
 }

--- a/Projects/Features/PlayerFeature/Sources/Views/PlaylistTableViewCell.swift
+++ b/Projects/Features/PlayerFeature/Sources/Views/PlaylistTableViewCell.swift
@@ -85,6 +85,12 @@ internal class PlaylistTableViewCell: UITableViewCell {
         }
     }
     
+    override var isEditing: Bool {
+        didSet {
+            updateConstraintPlayImageView()
+        }
+    }
+    
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         configureContents()
@@ -143,7 +149,7 @@ internal class PlaylistTableViewCell: UITableViewCell {
         
         superButton.snp.makeConstraints {
             $0.left.top.bottom.equalToSuperview()
-            $0.right.equalTo(titleLabel.snp.right)
+            $0.right.equalToSuperview()
         }
     }
     
@@ -176,6 +182,13 @@ extension PlaylistTableViewCell {
         } else {
             playImageView.isHidden = isPlaying
             waveStreamAnimationView.isHidden = !isPlaying
+        }
+    }
+    
+    private func updateConstraintPlayImageView() {
+        let offset = isEditing ? 22 : -20
+        self.playImageView.snp.updateConstraints {
+            $0.right.equalToSuperview().offset(offset)
         }
     }
     

--- a/Projects/Features/PlayerFeature/Sources/Views/PlaylistTableViewCell.swift
+++ b/Projects/Features/PlayerFeature/Sources/Views/PlaylistTableViewCell.swift
@@ -59,14 +59,10 @@ internal class PlaylistTableViewCell: UITableViewCell {
         $0.contentMode = .scaleAspectFit
     }
     
-    internal lazy var reorderImageView = UIImageView().then {
-        $0.image = DesignSystemAsset.Storage.move.image
-    }
-    
     internal var isPlaying: Bool = false {
         didSet {
             updateButtonHidden()
-            highlight()
+            updateLabelHighlight()
             isPlaying ? waveStreamAnimationView.play() : waveStreamAnimationView.pause()
         }
     }
@@ -89,73 +85,6 @@ internal class PlaylistTableViewCell: UITableViewCell {
     override func prepareForReuse() {
         super.prepareForReuse()
         isPlaying = false
-    }
-    
-    private func updateButtonHidden() {
-        if isEditing {
-            playImageView.isHidden = true
-            waveStreamAnimationView.isHidden = true
-        } else {
-            playImageView.isHidden = isPlaying
-            waveStreamAnimationView.isHidden = !isPlaying
-        }
-    }
-    
-    private func replaceAnimation() {
-        if isEditing {
-            UIView.animate(withDuration: 0.3) { [weak self] in // 오른쪽으로 사라지는 애니메이션
-                guard let self else { return }
-                self.playImageView.alpha = 0
-                self.playImageView.transform = CGAffineTransform(translationX: 100, y: 0)
-                self.playImageView.snp.updateConstraints {
-                    $0.right.equalTo(self.contentView.snp.right).offset(24)
-                }
-                self.waveStreamAnimationView.alpha = 0
-                self.waveStreamAnimationView.transform = CGAffineTransform(translationX: 100, y: 0)
-                self.waveStreamAnimationView.snp.updateConstraints {
-                    $0.right.equalTo(self.contentView.snp.right).offset(24)
-                }
-                self.layoutIfNeeded()
-            } completion: { [weak self] _ in
-                guard let self else { return }
-                self.playImageView.isHidden = true
-                self.waveStreamAnimationView.isHidden = true
-            }
-        } else {
-            self.playImageView.isHidden = isPlaying
-            self.waveStreamAnimationView.isHidden = !isPlaying
-            UIView.animate(withDuration: 0.3) { [weak self] in // 다시 돌아오는 애니메이션
-                guard let self else { return }
-                self.playImageView.alpha = 1
-                self.playImageView.transform = .identity
-                self.playImageView.snp.updateConstraints {
-                    $0.right.equalTo(self.contentView.snp.right).offset(-20)
-                }
-                self.waveStreamAnimationView.alpha = 1
-                self.waveStreamAnimationView.transform = .identity
-                self.waveStreamAnimationView.snp.updateConstraints {
-                    $0.right.equalTo(self.contentView.snp.right).offset(-20)
-                }
-                self.layoutIfNeeded()
-            }
-            
-        }
-    }
-    
-    private func highlight() {
-        titleLabel.textColor = isPlaying ? DesignSystemAsset.PrimaryColor.point.color : DesignSystemAsset.GrayColor.gray900.color
-        artistLabel.textColor = isPlaying ? DesignSystemAsset.PrimaryColor.point.color : DesignSystemAsset.GrayColor.gray900.color
-    }
-    
-    internal func setContent(song: SongEntity) {
-        self.thumbnailImageView.kf.setImage(
-            with: URL(string: Utility.WMImageAPI.fetchYoutubeThumbnail(id: song.id).toString),
-            placeholder: DesignSystemAsset.Logo.placeHolderSmall.image,
-            options: [.transition(.fade(0.2))]
-        )
-        
-        self.titleLabel.text = song.title
-        self.artistLabel.text = song.artist
     }
     
     private func configureContents() {
@@ -197,6 +126,76 @@ internal class PlaylistTableViewCell: UITableViewCell {
             $0.width.height.equalTo(32)
             $0.centerY.equalTo(contentView.snp.centerY)
             $0.right.equalTo(contentView.snp.right).offset(-20)
+        }
+    }
+    
+}
+
+extension PlaylistTableViewCell {
+    internal func setContent(song: SongEntity) {
+        self.thumbnailImageView.kf.setImage(
+            with: URL(string: Utility.WMImageAPI.fetchYoutubeThumbnail(id: song.id).toString),
+            placeholder: DesignSystemAsset.Logo.placeHolderSmall.image,
+            options: [.transition(.fade(0.2))]
+        )
+        
+        self.titleLabel.text = song.title
+        self.artistLabel.text = song.artist
+    }
+    
+    private func updateButtonHidden() {
+        if isEditing {
+            playImageView.isHidden = true
+            waveStreamAnimationView.isHidden = true
+        } else {
+            playImageView.isHidden = isPlaying
+            waveStreamAnimationView.isHidden = !isPlaying
+        }
+    }
+    
+    private func updateLabelHighlight() {
+        titleLabel.textColor = isPlaying ? DesignSystemAsset.PrimaryColor.point.color : DesignSystemAsset.GrayColor.gray900.color
+        artistLabel.textColor = isPlaying ? DesignSystemAsset.PrimaryColor.point.color : DesignSystemAsset.GrayColor.gray900.color
+    }
+    
+    private func replaceAnimation() {
+        if isEditing {
+            UIView.animate(withDuration: 0.3) { [weak self] in // 오른쪽으로 사라지는 애니메이션
+                guard let self else { return }
+                self.playImageView.alpha = 0
+                self.playImageView.transform = CGAffineTransform(translationX: 100, y: 0)
+                self.playImageView.snp.updateConstraints {
+                    $0.right.equalTo(self.contentView.snp.right).offset(24)
+                }
+                self.waveStreamAnimationView.alpha = 0
+                self.waveStreamAnimationView.transform = CGAffineTransform(translationX: 100, y: 0)
+                self.waveStreamAnimationView.snp.updateConstraints {
+                    $0.right.equalTo(self.contentView.snp.right).offset(24)
+                }
+                self.layoutIfNeeded()
+            } completion: { [weak self] _ in
+                guard let self else { return }
+                self.playImageView.isHidden = true
+                self.waveStreamAnimationView.isHidden = true
+            }
+        } else {
+            self.playImageView.isHidden = isPlaying
+            self.waveStreamAnimationView.isHidden = !isPlaying
+            UIView.animate(withDuration: 0.3) { [weak self] in // 다시 돌아오는 애니메이션
+                guard let self else { return }
+                self.playImageView.alpha = 1
+                self.playImageView.transform = .identity
+                self.playImageView.snp.updateConstraints {
+                    $0.right.equalTo(self.contentView.snp.right).offset(-20)
+                }
+                self.waveStreamAnimationView.alpha = 1
+                self.waveStreamAnimationView.transform = .identity
+                self.waveStreamAnimationView.snp.updateConstraints {
+                    $0.right.equalTo(self.contentView.snp.right).offset(-20)
+                }
+                self.layoutIfNeeded()
+            }
+            
         }
     }
     

--- a/Projects/Features/PlayerFeature/Sources/Views/PlaylistTableViewCell.swift
+++ b/Projects/Features/PlayerFeature/Sources/Views/PlaylistTableViewCell.swift
@@ -72,22 +72,11 @@ internal class PlaylistTableViewCell: UITableViewCell {
     internal var model: (index: Int, song: SongEntity?) = (0, nil)
     
     
-    internal var isPlaying: Bool = false {
-        didSet {
-            updateButtonHidden()
-            updateLabelHighlight()
-        }
-    }
+    internal var isPlaying: Bool = false
     
     internal var isAnimating: Bool = false {
         didSet {
             isAnimating ? waveStreamAnimationView.play() : waveStreamAnimationView.pause()
-        }
-    }
-    
-    override var isEditing: Bool {
-        didSet {
-            updateConstraintPlayImageView()
         }
     }
     
@@ -156,7 +145,8 @@ internal class PlaylistTableViewCell: UITableViewCell {
 }
 
 extension PlaylistTableViewCell {
-    internal func setContent(song: SongEntity, _ isEditing: Bool, index: Int) {
+    internal func setContent(song: SongEntity, index: Int, isEditing: Bool, isPlaying: Bool, isAnimating: Bool) {
+        print("셋컨텐트 호출됨", song.title)
         self.thumbnailImageView.kf.setImage(
             with: URL(string: Utility.WMImageAPI.fetchYoutubeThumbnail(id: song.id).toString),
             placeholder: DesignSystemAsset.Logo.placeHolderSmall.image,
@@ -165,17 +155,19 @@ extension PlaylistTableViewCell {
         
         self.titleLabel.text = song.title
         self.artistLabel.text = song.artist
-        
-        self.backgroundColor = song.isSelected ? DesignSystemAsset.GrayColor.gray200.color : UIColor.clear
-        self.superButton.isHidden = !isEditing
         self.model = (index, song)
+        self.backgroundColor = song.isSelected ? DesignSystemAsset.GrayColor.gray200.color : UIColor.clear
+        
+        self.updateButtonHidden(isEditing: isEditing, isPlaying: isPlaying)
+        self.updateConstraintPlayImageView(isEditing: isEditing)
+        self.updateLabelHighlight(isPlaying: isPlaying)
     }
     
     @objc func superButtonSelectedAction() {
         delegate?.superButtonTapped(index: model.index)
     }
     
-    private func updateButtonHidden() {
+    private func updateButtonHidden(isEditing: Bool, isPlaying: Bool) {
         if isEditing {
             playImageView.isHidden = true
             waveStreamAnimationView.isHidden = true
@@ -183,16 +175,17 @@ extension PlaylistTableViewCell {
             playImageView.isHidden = isPlaying
             waveStreamAnimationView.isHidden = !isPlaying
         }
+        superButton.isHidden = !isEditing
     }
     
-    private func updateConstraintPlayImageView() {
+    private func updateConstraintPlayImageView(isEditing: Bool) {
         let offset = isEditing ? 22 : -20
         self.playImageView.snp.updateConstraints {
             $0.right.equalToSuperview().offset(offset)
         }
     }
     
-    private func updateLabelHighlight() {
+    private func updateLabelHighlight(isPlaying: Bool) {
         titleLabel.textColor = isPlaying ? DesignSystemAsset.PrimaryColor.point.color : DesignSystemAsset.GrayColor.gray900.color
         artistLabel.textColor = isPlaying ? DesignSystemAsset.PrimaryColor.point.color : DesignSystemAsset.GrayColor.gray900.color
     }

--- a/Projects/Features/PlayerFeature/Sources/Views/PlaylistTableViewCell.swift
+++ b/Projects/Features/PlayerFeature/Sources/Views/PlaylistTableViewCell.swift
@@ -15,8 +15,8 @@ import Lottie
 import Kingfisher
 import Utility
 
-internal protocol PlayListCellDelegate: AnyObject {
-    func buttonTapped(index: Int)
+internal protocol PlaylistTableViewCellDelegate: AnyObject {
+    func superButtonTapped(index: Int)
 }
 
 internal class PlaylistTableViewCell: UITableViewCell {
@@ -67,7 +67,7 @@ internal class PlaylistTableViewCell: UITableViewCell {
         $0.addTarget(self, action: #selector(superButtonSelectedAction), for: .touchUpInside)
     }
     
-    internal weak var delegate: PlayListCellDelegate?
+    internal weak var delegate: PlaylistTableViewCellDelegate?
     
     internal var model: (index: Int, song: SongEntity?) = (0, nil)
     
@@ -166,7 +166,7 @@ extension PlaylistTableViewCell {
     }
     
     @objc func superButtonSelectedAction() {
-        delegate?.buttonTapped(index: model.index)
+        delegate?.superButtonTapped(index: model.index)
     }
     
     private func updateButtonHidden() {

--- a/Projects/Features/PlayerFeature/Sources/Views/PlaylistTableViewCell.swift
+++ b/Projects/Features/PlayerFeature/Sources/Views/PlaylistTableViewCell.swift
@@ -63,7 +63,12 @@ internal class PlaylistTableViewCell: UITableViewCell {
         didSet {
             updateButtonHidden()
             updateLabelHighlight()
-            isPlaying ? waveStreamAnimationView.play() : waveStreamAnimationView.pause()
+        }
+    }
+    
+    internal var isAnimating: Bool = false {
+        didSet {
+            isAnimating ? waveStreamAnimationView.play() : waveStreamAnimationView.pause()
         }
     }
     

--- a/Projects/Features/PlayerFeature/Sources/Views/PlaylistTableViewCell.swift
+++ b/Projects/Features/PlayerFeature/Sources/Views/PlaylistTableViewCell.swift
@@ -146,6 +146,8 @@ extension PlaylistTableViewCell {
         
         self.titleLabel.text = song.title
         self.artistLabel.text = song.artist
+        
+        self.backgroundColor = song.isSelected ? DesignSystemAsset.GrayColor.gray200.color : UIColor.clear
     }
     
     private func updateButtonHidden() {

--- a/Projects/Features/PlayerFeature/Sources/Views/PlaylistTableViewCell.swift
+++ b/Projects/Features/PlayerFeature/Sources/Views/PlaylistTableViewCell.swift
@@ -59,6 +59,8 @@ internal class PlaylistTableViewCell: UITableViewCell {
         $0.contentMode = .scaleAspectFit
     }
     
+    internal lazy var superButton = UIButton()
+    
     internal var isPlaying: Bool = false {
         didSet {
             updateButtonHidden()
@@ -99,6 +101,7 @@ internal class PlaylistTableViewCell: UITableViewCell {
         self.contentView.addSubview(self.artistLabel)
         self.contentView.addSubview(self.playImageView)
         self.contentView.addSubview(self.waveStreamAnimationView)
+        self.contentView.addSubview(self.superButton)
         
         let height = 40
         let width = height * 16 / 9
@@ -132,6 +135,11 @@ internal class PlaylistTableViewCell: UITableViewCell {
             $0.centerY.equalTo(contentView.snp.centerY)
             $0.right.equalTo(contentView.snp.right).offset(-20)
         }
+        
+        superButton.snp.makeConstraints {
+            $0.left.top.bottom.equalToSuperview()
+            $0.right.equalTo(playImageView.snp.left)
+        }
     }
     
 }
@@ -148,6 +156,7 @@ extension PlaylistTableViewCell {
         self.artistLabel.text = song.artist
         
         self.backgroundColor = song.isSelected ? DesignSystemAsset.GrayColor.gray200.color : UIColor.clear
+        self.superButton.isHidden = !isEditing
     }
     
     private func updateButtonHidden() {

--- a/Projects/Features/PlayerFeature/Sources/Views/PlaylistView.swift
+++ b/Projects/Features/PlayerFeature/Sources/Views/PlaylistView.swift
@@ -58,6 +58,10 @@ public final class PlaylistView: UIView {
         $0.effect = UIBlurEffect(style: .regular)
     }
     
+    private lazy var homeIndicatorBackgroundView = UIView().then {
+        $0.backgroundColor = UIColor(red: 1, green: 1, blue: 1, alpha: 0.5)
+    }
+    
     internal lazy var miniPlayerView = UIView().then {
         $0.backgroundColor = UIColor(red: 1, green: 1, blue: 1, alpha: 0.5)
     }
@@ -129,6 +133,7 @@ private extension PlaylistView {
         self.configurePlaylist()
         self.configureBlur()
         self.configureMiniPlayer()
+        self.configreHomeIndicatorBackgroundView()
     }
     
     private func configureSubViews() {
@@ -141,6 +146,7 @@ private extension PlaylistView {
         contentView.addSubview(playlistTableView)
         contentView.addSubview(blurEffectView)
         contentView.addSubview(miniPlayerView)
+        contentView.addSubview(homeIndicatorBackgroundView)
         miniPlayerView.addSubview(miniPlayerContentView)
         miniPlayerContentView.addSubview(thumbnailImageView)
         miniPlayerContentView.addSubview(miniPlayerStackView)
@@ -161,10 +167,9 @@ private extension PlaylistView {
     }
     
     private func configureContent() {
-        
         contentView.snp.makeConstraints {
             $0.top.equalToSuperview().offset(Utility.STATUS_BAR_HEGHIT())
-            $0.bottom.equalToSuperview().offset(-SAFEAREA_BOTTOM_HEIGHT())
+            $0.bottom.equalToSuperview()
             $0.horizontalEdges.equalToSuperview()
         }
     }
@@ -205,7 +210,7 @@ private extension PlaylistView {
     
     private func configureBlur() {
         blurEffectView.snp.makeConstraints {
-            $0.height.equalTo(56)
+            $0.height.equalTo(56 + SAFEAREA_BOTTOM_HEIGHT())
             $0.bottom.left.right.equalToSuperview()
         }
     }
@@ -213,7 +218,8 @@ private extension PlaylistView {
     private func configureMiniPlayer() {
         miniPlayerView.snp.makeConstraints {
             $0.height.equalTo(56)
-            $0.bottom.left.right.equalToSuperview()
+            $0.left.right.equalToSuperview()
+            $0.bottom.equalToSuperview().offset(-SAFEAREA_BOTTOM_HEIGHT())
         }
         
         totalPlayTimeView.snp.makeConstraints {
@@ -252,5 +258,12 @@ private extension PlaylistView {
         miniPlayerStackView.addArrangedSubview(nextButton)
         miniPlayerStackView.addArrangedSubview(shuffleButton)
         
+    }
+    
+    private func configreHomeIndicatorBackgroundView() {
+        homeIndicatorBackgroundView.snp.makeConstraints {
+            $0.height.equalTo(SAFEAREA_BOTTOM_HEIGHT())
+            $0.left.right.bottom.equalToSuperview()
+        }
     }
 }

--- a/Projects/Features/PlayerFeature/Sources/Views/PlaylistView.swift
+++ b/Projects/Features/PlayerFeature/Sources/Views/PlaylistView.swift
@@ -154,18 +154,17 @@ private extension PlaylistView {
     }
     
     private func configureBackground() {
-        let safeAreaBottomInset: CGFloat = UIApplication.shared.windows.first?.safeAreaInsets.bottom ?? 0
         backgroundView.snp.makeConstraints {
             $0.top.horizontalEdges.equalToSuperview()
-            $0.bottom.equalToSuperview().offset(-safeAreaBottomInset)
+            $0.bottom.equalToSuperview().offset(-SAFEAREA_BOTTOM_HEIGHT())
         }
     }
     
     private func configureContent() {
-        let safeAreaBottomInset: CGFloat = UIApplication.shared.windows.first?.safeAreaInsets.bottom ?? 0
+        
         contentView.snp.makeConstraints {
             $0.top.equalToSuperview().offset(Utility.STATUS_BAR_HEGHIT())
-            $0.bottom.equalToSuperview().offset(-safeAreaBottomInset)
+            $0.bottom.equalToSuperview().offset(-SAFEAREA_BOTTOM_HEIGHT())
             $0.horizontalEdges.equalToSuperview()
         }
     }
@@ -196,6 +195,7 @@ private extension PlaylistView {
     }
     
     private func configurePlaylist() {
+        playlistTableView.tableFooterView = UIView(frame: CGRect(x: 0, y: 0, width: APP_WIDTH(), height: 56))
         playlistTableView.snp.makeConstraints {
             $0.top.equalTo(titleBarView.snp.bottom)
             $0.horizontalEdges.equalToSuperview()

--- a/Projects/Modules/Utility/Sources/Extensions/Extension+Collection.swift
+++ b/Projects/Modules/Utility/Sources/Extensions/Extension+Collection.swift
@@ -1,0 +1,15 @@
+//
+//  Extension+Collection.swift
+//  Utility
+//
+//  Created by YoungK on 2023/04/13.
+//  Copyright © 2023 yongbeomkwak. All rights reserved.
+//
+
+import Foundation
+
+public extension Collection {
+    subscript(safe index: Index) -> Iterator.Element? {
+        return indices.contains(index) ? self[index] : nil
+    }
+}

--- a/Projects/Modules/Utility/Sources/Extensions/Extension+UILabel.swift
+++ b/Projects/Modules/Utility/Sources/Extensions/Extension+UILabel.swift
@@ -22,19 +22,11 @@ public extension UILabel {
         paragraphStyle.lineSpacing = lineSpacing
         paragraphStyle.lineHeightMultiple = lineHeightMultiple
         
-        let attributedString:NSMutableAttributedString
-        if let labelattributedText = self.attributedText {
-            attributedString = NSMutableAttributedString(attributedString: labelattributedText)
-        } else {
-            attributedString = NSMutableAttributedString(string: labelText)
-        }
-        
-        attributedString.addAttribute(NSAttributedString.Key.paragraphStyle,
-                                      value: paragraphStyle,
-                                      range: NSMakeRange(0, attributedString.length))
-        attributedString.addAttribute(NSAttributedString.Key.kern,
-                                      value: kernValue,
-                                      range: NSMakeRange(0, attributedString.length))
+        let attributedString = NSMutableAttributedString(string: labelText,
+                                                         attributes: [
+                                                            .paragraphStyle: paragraphStyle,
+                                                            .kern: kernValue
+                                                         ])
         
         self.attributedText = attributedString
     }


### PR DESCRIPTION
## 개요
기존에 설계한 방식은 DataSource가 최초 생성될 때 원본 PlayList 에서 pull 해오고, 사용자 동작에 따라 DataSource를 변경시키고 DataSource에 변경사항이 생길때마다 원본 PlayList로 push 하는 구조로 설계했었습니다. 
하지만 forward, backward, 선택, 순서변경 등등 모든 메소드가 PlayList에 구현되어있던 상태이고 저 구조를 적용하려면 PlayList에 있는 메소드들을 전부 뷰모델로 끌어내려야 하는 상황이었습니다. 

그래서 구조에 대한 고민끝에 뷰모델은 PlayList를 변경시키고, DataSource는 원본 PlayList의 변경사항을 구독하는 방식으로 수정하기로했습니다.

## 작업사항
DataSource는 PlayList를 관찰하고 변경사항이 생기면 계속 pull 하는 구조로 변경하였습니다.
CurrentPlayIndex를 수동으로 관리하는게 위험하다고 생각되어 PlayListItem의 isPlaying 변수를 두고 isPlaying을 추적하는 구조로 변경하였습니다.

Closes #195, #202, #207