### PR TITLE
🔀 :: 플레이어관련 각종 오류 해결

### DIFF
--- a/Projects/App/Sources/Application/NeedleGenerated.swift
+++ b/Projects/App/Sources/Application/NeedleGenerated.swift
@@ -130,6 +130,9 @@ private class PlayerDependencyf8a3d594cc3b9254f8adProvider: PlayerDependency {
     var playlistComponent: PlaylistComponent {
         return appComponent.playlistComponent
     }
+    var containSongsComponent: ContainSongsComponent {
+        return appComponent.containSongsComponent
+    }
     private let appComponent: AppComponent
     init(appComponent: AppComponent) {
         self.appComponent = appComponent
@@ -837,6 +840,7 @@ extension PlayerComponent: Registration {
         keyPathToName[\PlayerDependency.fetchLikeNumOfSongUseCase] = "fetchLikeNumOfSongUseCase-any FetchLikeNumOfSongUseCase"
         keyPathToName[\PlayerDependency.fetchFavoriteSongsUseCase] = "fetchFavoriteSongsUseCase-any FetchFavoriteSongsUseCase"
         keyPathToName[\PlayerDependency.playlistComponent] = "playlistComponent-PlaylistComponent"
+        keyPathToName[\PlayerDependency.containSongsComponent] = "containSongsComponent-ContainSongsComponent"
     }
 }
 extension MainTabBarComponent: Registration {

--- a/Projects/Features/CommonFeature/Sources/PlayState/PlayState+Public.swift
+++ b/Projects/Features/CommonFeature/Sources/PlayState/PlayState+Public.swift
@@ -24,7 +24,7 @@ public extension PlayState {
             self.playList.changeCurrentPlayIndex(to: self.playList.lastIndex)
         }
         
-        if self.state == .cued { self.switchPlayerMode(to: .mini) }
+        if self.state == .unstarted { self.switchPlayerMode(to: .mini) }
         self.load(at: firstSong)
         
         songs.dropFirst().forEach { song in
@@ -41,7 +41,7 @@ public extension PlayState {
                 self.playList.append(PlayListItem(item: song))
             }
         }
-        // player.stop 하면 .cued 상태
-        if self.state == .cued { self.switchPlayerMode(to: .mini) }
+        
+        if self.state == .unstarted { self.switchPlayerMode(to: .mini) }
     }
 }

--- a/Projects/Features/CommonFeature/Sources/PlayState/PlayState+YoutubePlayer.swift
+++ b/Projects/Features/CommonFeature/Sources/PlayState/PlayState+YoutubePlayer.swift
@@ -24,9 +24,10 @@ extension PlayState {
     
     /// ⏹️ 플레이어 닫기
     public func stop() {
-        self.player.stop()
+        self.player.stop() // stop만 하면 playbackState가 .cued로 들어감
         self.currentSong = nil
         self.progress.clear()
+        self.player.cue(source: .video(id: "")) // playbackState를 .unstarted로 바꿈
         //self.playList.removeAll()
     }
     

--- a/Projects/Features/PlayerFeature/Sources/Components/PlayerComponent.swift
+++ b/Projects/Features/PlayerFeature/Sources/Components/PlayerComponent.swift
@@ -1,4 +1,5 @@
 import Foundation
+import CommonFeature
 import DomainModule
 import NeedleFoundation
 
@@ -9,6 +10,7 @@ public protocol PlayerDependency: Dependency {
     var fetchLikeNumOfSongUseCase: any FetchLikeNumOfSongUseCase { get }
     var fetchFavoriteSongsUseCase: any FetchFavoriteSongsUseCase { get }
     var playlistComponent: PlaylistComponent { get }
+    var containSongsComponent: ContainSongsComponent { get }
 }
 
 public final class PlayerComponent: Component<PlayerDependency> {
@@ -21,7 +23,8 @@ public final class PlayerComponent: Component<PlayerDependency> {
                 fetchLikeNumOfSongUseCase: dependency.fetchLikeNumOfSongUseCase,
                 fetchFavoriteSongsUseCase: dependency.fetchFavoriteSongsUseCase
             ),
-            playlistComponent: dependency.playlistComponent
+            playlistComponent: dependency.playlistComponent,
+            containSongsComponent: dependency.containSongsComponent
         )
     }
 }

--- a/Projects/Features/PlayerFeature/Sources/ViewControllers/PlayerViewController.swift
+++ b/Projects/Features/PlayerFeature/Sources/ViewControllers/PlayerViewController.swift
@@ -31,11 +31,13 @@ public class PlayerViewController: UIViewController {
         $0.isHidden = true
     }
     
-    var playlistComponent: PlaylistComponent!
+    internal var playlistComponent: PlaylistComponent!
+    internal var containSongsComponent: ContainSongsComponent!
     
-    init(viewModel: PlayerViewModel, playlistComponent: PlaylistComponent) {
+    init(viewModel: PlayerViewModel, playlistComponent: PlaylistComponent, containSongsComponent: ContainSongsComponent) {
         self.viewModel = viewModel
         self.playlistComponent = playlistComponent
+        self.containSongsComponent = containSongsComponent
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -122,7 +124,8 @@ private extension PlayerViewController {
         bindShowPlaylist(output: output)
         bindShowToastMessage(output: output)
         bindShowConfirmModal(output: output)
-        
+        bindShowContainSongsViewController(output: output)
+
     }
         
     private func bindPlayButtonImages(output: PlayerViewModel.Output) {
@@ -307,6 +310,15 @@ private extension PlayerViewController {
                 self?.playState.switchPlayerMode(to: .mini)
             }, cancelCompletion: {
             }))
+        }.store(in: &subscription)
+    }
+    
+    private func bindShowContainSongsViewController(output: PlayerViewModel.Output) {
+        output.showContainSongsViewController.sink { [weak self] songId in
+            guard let self else { return }
+            let viewController = self.containSongsComponent.makeView(songs: [songId])
+            viewController.modalPresentationStyle = .overFullScreen
+            self.present(viewController, animated: true)
         }.store(in: &subscription)
     }
     

--- a/Projects/Features/PlayerFeature/Sources/ViewControllers/PlayerViewController.swift
+++ b/Projects/Features/PlayerFeature/Sources/ViewControllers/PlayerViewController.swift
@@ -255,9 +255,11 @@ private extension PlayerViewController {
     
     private func bindLyricsTracking(output: PlayerViewModel.Output) {
         output.playTimeValue
-            .compactMap { [weak self] value -> Int? in
-                guard let self = self, value > 0, !self.viewModel.isLyricsScrolling else { return nil }
-                return self.viewModel.getCurrentLyricsIndex(value)
+            .compactMap { [weak self] time -> Int? in
+                guard let self = self, time > 0,
+                        !self.viewModel.lyricsDict.isEmpty,
+                        !self.viewModel.isLyricsScrolling else { return nil }
+                return self.viewModel.getCurrentLyricsIndex(time)
             }
             .sink { [weak self] index in
                 self?.updateLyricsHighlight(index: index)

--- a/Projects/Features/PlayerFeature/Sources/ViewControllers/PlaylistViewController.swift
+++ b/Projects/Features/PlayerFeature/Sources/ViewControllers/PlaylistViewController.swift
@@ -146,16 +146,7 @@ private extension PlaylistViewController {
     }
     
     private func bindThumbnail(output: PlaylistViewModel.Output) {
-        if let song = playState.player.source {
-            let thumbnailImageURL = Utility.WMImageAPI.fetchYoutubeThumbnail(id: song.id).toString
-            self.playlistView.thumbnailImageView.kf.setImage(
-                with: URL(string: thumbnailImageURL),
-                placeholder: DesignSystemAsset.Logo.placeHolderSmall.image,
-                options: [.transition(.fade(0.2))])
-        }
-        
         output.thumbnailImageURL
-            .dropFirst()
             .sink { [weak self] thumbnailImageURL in
             self?.playlistView.thumbnailImageView.kf.setImage(
                 with: URL(string: thumbnailImageURL),

--- a/Projects/Features/PlayerFeature/Sources/ViewModels/PlayerViewModel.swift
+++ b/Projects/Features/PlayerFeature/Sources/ViewModels/PlayerViewModel.swift
@@ -275,6 +275,9 @@ final class PlayerViewModel: ViewModelType {
     }
     
     private func handleCurrentSongChanged(song: SongEntity?, output: Output) {
+        lyricsDict.removeAll()
+        sortedLyrics.removeAll()
+        
         if let song = song {
             let thumbnailURL = Utility.WMImageAPI.fetchYoutubeThumbnail(id: song.id).toString
             output.thumbnailImageURL.send(thumbnailURL)
@@ -282,6 +285,7 @@ final class PlayerViewModel: ViewModelType {
             output.artistText.send(song.artist)
             output.viewsCountText.send(self.formatNumber(song.views))
             output.likeCountText.send("준비중")
+            sortedLyrics.append("가사를 불러오는 중입니다.")
         } else {
             output.thumbnailImageURL.send("")
             output.titleText.send("")
@@ -289,10 +293,9 @@ final class PlayerViewModel: ViewModelType {
             output.viewsCountText.send("조회수")
             output.likeCountText.send("좋아요")
             output.likeState.send(false)
-            lyricsDict.removeAll()
-            sortedLyrics.removeAll()
-            output.lyricsDidChangedEvent.send(true)
         }
+        
+        output.lyricsDidChangedEvent.send(true)
         
     }
     

--- a/Projects/Features/PlayerFeature/Sources/ViewModels/PlayerViewModel.swift
+++ b/Projects/Features/PlayerFeature/Sources/ViewModels/PlayerViewModel.swift
@@ -56,6 +56,7 @@ final class PlayerViewModel: ViewModelType {
         var willShowPlaylist = PassthroughSubject<Bool, Never>()
         var showToastMessage = PassthroughSubject<String, Never>()
         var showConfirmModal = PassthroughSubject<String, Never>()
+        var showContainSongsViewController = PassthroughSubject<String, Never>()
     }
     
     var fetchLyricsUseCase: FetchLyricsUseCase!
@@ -183,6 +184,9 @@ final class PlayerViewModel: ViewModelType {
                 if !isLoggedIn {
                     output.showConfirmModal.send("로그인이 필요한 서비스입니다.\n로그인 하시겠습니까?")
                     return
+                }
+                if let currentSong = self.playState.currentSong {
+                    output.showContainSongsViewController.send(currentSong.id)
                 }
             }.store(in: &subscription)
         


### PR DESCRIPTION
## 개요

## 작업사항
- 플레이어 화면에서 곡담기 기능 연결
- 재생중인 곡 변경되면 "가사를 불러오는 중입니다." 문구 추가

### 플레이어를 닫았다가 재생목록 추가를 눌러 빈 플레이어를 띄웠을 때, 재생버튼을 누르면 마지막에 재생했던 곡이 재생되던 문제 해결
```Swift
YoutubePlayer.stop() // playbackState 가 .cued로 들어가서 play()를 했을때 cue에 들어있던 source가 재생됨
YoutubePlayer.cue(source: .video(id: "")) // 이 코드 추가로 큐에 빈 source를 추가시키고 playbackState를 .unstarted 로 변경시킴
```


### 가사를 수신하기 전 플레이어가 먼저 로드되면 크래시나던 문제 수정

재생중인 곡이 변경되면, 플레이어가 새로 load 되면서 재생시간을 불러오는 작업과 가사를 요청하는 두개의 네트워크 작업이 있음
플레이어는 플레이어의 재생시간 변화를 구독해 하이라이팅과 센터스크롤을 하는데,
가사가 도착하기 전에 플레이어가 먼저 load 되고 재생시간이 불러와지면 아래 코드에서 에러가 나는 문제였음
가사가 존재할때만 sink문을 타도록 compactMap에서 가사존재여부 검사
```Swift
playerView.lyricsTableView.scrollToRow(at: IndexPath(row: index, section: 0), at: .middle, animated: true)
```
![image](https://user-images.githubusercontent.com/60254939/232088492-f1148c5d-f285-43a1-9e31-a42eba6f8123.png)



closes #174, #208